### PR TITLE
fix: PKNCAresults.getGroups with end column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@ the dosing including dose amount and route.
 * Removed native pipes (`|>`) so that PKNCA will work with older versions of R
   (#304).
 * Missing dosing times to `pk.calc.c0()` will not cause an error (#344)
+* `getGroups()` includes the `end` column when applied to a `PKNCAresults` object (#419).
 
 # PKNCA 0.11.0
 

--- a/R/class-PKNCAresults.R
+++ b/R/class-PKNCAresults.R
@@ -113,7 +113,7 @@ getGroups.PKNCAresults <- function(object,
                                    form=formula(object$data$conc), level,
                                    data=object$result, sep) {
   # Include the start time as a group; this may be dropped later
-  grpnames <- c(unlist(object$data$conc$columns$groups), "start")
+  grpnames <- c(unlist(object$data$conc$columns$groups), "start", "end")
   if (is_sparse_pk(object)) {
     grpnames <- setdiff(grpnames, object$data$conc$columns$subject)
   }

--- a/tests/testthat/test-class-PKNCAresults.R
+++ b/tests/testthat/test-class-PKNCAresults.R
@@ -397,6 +397,10 @@ test_that("getGroups.PKNCAresults", {
     getGroups(myresult, level=2:3),
     myresult$result[, c("ID", "start")]
   )
+  expect_equal(
+    getGroups(myresult, level=3:4),
+    myresult$result[, c("start", "end")]
+  )
 })
 
 test_that("group_vars.PKNCAresult", {


### PR DESCRIPTION
Closes #419 by including in `grpnames` the "end" column by default for PKNCAresults. A test was also added.