### PR TITLE
half.life calculation for intervals involving multiple doses and/or infusions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ the dosing including dose amount and route.
 
 * Units for fraction excretion parameter (fe) are now accurately captured as
   amount/dose units rather than "fraction" (#426)
+* `lambda.z` calculations will now only consider time points that occur after the last dose & for infusions that are after the dose administration.
 
 # PKNCA 0.12.0
 

--- a/R/half.life.R
+++ b/R/half.life.R
@@ -132,7 +132,7 @@ pk.calc.half.life <- function(conc, time, tmax, tlast,
   # Filter out points with 0 concentration. as.numeric() to handle units objects
   data <- data[as.numeric(data$conc) > 0,]
   # Filter out points that start before the last dose and/or involve the absorption phase (infusion)
-  if (!is.null(time.dose)) {
+  if (!is.null(time.dose) && !is.na(time.dose) && !is.na(duration.dose)) {
     data <- data[as.numeric(data$time) > as.numeric(time.dose) + as.numeric(duration.dose), ]
   }
   # Prepare the return values

--- a/R/half.life.R
+++ b/R/half.life.R
@@ -131,9 +131,12 @@ pk.calc.half.life <- function(conc, time, tmax, tlast,
   data$log_conc <- log(data$conc)
   # Filter out points with 0 concentration. as.numeric() to handle units objects
   data <- data[as.numeric(data$conc) > 0,]
-  # Filter out points that start before the last dose and/or involve the absorption phase (infusion)
-  if (!is.null(time.dose) && !is.na(time.dose) && !is.na(duration.dose)) {
-    data <- data[as.numeric(data$time) > as.numeric(time.dose) + as.numeric(duration.dose), ]
+  if (!is.null(time.dose)) {
+    # If multiple doses are within the interval, consider only the last one
+    time.dose = time.dose[length(time.dose)]
+    duration.dose = duration.dose[length(duration.dose)]
+    if (!is.na(time.dose) && !is.na(duration.dose))
+      data <- data[as.numeric(data$time) > as.numeric(time.dose) + as.numeric(duration.dose), ]
   }
   # Prepare the return values
   ret <- data.frame(

--- a/vignettes/v06-half-life-calculation.Rmd
+++ b/vignettes/v06-half-life-calculation.Rmd
@@ -29,6 +29,7 @@ When automatic point selection is performed for curve stripping, the algorithm d
 All sets of points that are applicable according to the current options are selected.
 
 * Drop all BLQ values, then
+* Drop all points before the end of the last dose administration, then
 * Choose all sets of points that start from the $T_{last}$ and step back:
     * at least `r PKNCA.options("min.hl.points")` points (customizable with `PKNCA.options("min.hl.points")`)
     * `r c("Not including", "Including")[PKNCA.options("allow.tmax.in.half.life") + 1]` $T_{max}$ (customizable with `PKNCA.options("allow.tmax.in.half.life")`)


### PR DESCRIPTION
Proposal for closing #139 

- Added `time.dose` and `duration.dose` arguments in `pk.calc.half.life` to exclude points from the half-life calculation that occur after last dose end of administration (multi dose and/or infusion). The filtering is only done when the dose arguments are available and not NA.

- Added a test to verify that `lambda.z.time.first` correctly shifts based on the `duration.dose` parameter, ensuring the function excludes absorption-phase data points in infusion studies.