### PR TITLE
Clarify sparse grouping in the sparse NCA vignette (#530)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,10 @@ the dosing including dose amount and route.
 
 ## Improvements
 
+* The sparse NCA vignette now explains how subjects are grouped: sparse
+  parameters pool all subjects that share the same concentration grouping
+  variables with the subject column removed (#530).
+
 * `normalize.data.frame()` now validates that `norm_table` contains exactly one
   row when used with ungrouped data, giving a clear error message instead of
   silently producing incorrect results.

--- a/vignettes/v04-sparse.Rmd
+++ b/vignettes/v04-sparse.Rmd
@@ -48,6 +48,27 @@ Sparse NCA requires that subject numbers (or animal numbers) are given, even if 
 d_sparse$id <- 1:nrow(d_sparse)
 ```
 
+## How Subjects Are Grouped for Sparse Calculations
+
+With dense (normal) PK, every subject has a full concentration-time profile, so NCA parameters are calculated one subject at a time.  Sparse parameters are different: they are calculated from the *pooled* samples of every subject that belongs to the same group.  Knowing what defines a "group" is therefore important.
+
+The groups are taken from the grouping variables on the right of the `|` in the `PKNCAconc()` formula, **with the subject column removed**.  Every subject that shares the same combination of the remaining (non-subject) grouping variables contributes to a single pooled sparse concentration-time profile.
+
+In the simple example above, the formula is `conc~time|id`.  Here `id` is the subject, and removing it leaves no other grouping variables, so all of the data form a single sparse group.
+
+The behavior is easier to see with more grouping variables.  Suppose the concentration and dose objects are created with the formulas below (illustrative code; not run here):
+
+```{r eval=FALSE}
+o_conc_sparse <- PKNCAconc(d_conc, conc~time|matrix+drug+usubjid/analyte, sparse=TRUE)
+o_dose_sparse <- PKNCAdose(d_dose, dose~time|drug+usubjid)
+```
+
+`usubjid` is the subject because, by default, the subject is the last grouping variable before any `/` (or the last grouping variable when there is no `/`).  After dropping the subject, the grouping variables that remain are `matrix`, `drug`, and `analyte`.  Sparse parameters are therefore calculated by combining all subjects within each unique combination of `matrix`, `drug`, and `analyte`.
+
+In other words, with that formula PKNCA does **not** keep each `usubjid` separate, and it does **not** group by `matrix`, `drug`, or `analyte` alone.  It pools subjects using the full set of non-subject grouping variables together (`matrix` + `drug` + `analyte`).
+
+Because subjects are pooled within a group, all subjects in a group must share the same dosing.  If subjects in the same group have different dosing information (for example, different dose amounts or dose times), PKNCA stops with an error identifying the inconsistent group.
+
 # Calculate!
 
 Setup PKNCA for calculations and then calculate!


### PR DESCRIPTION
## Summary

Addresses [discussion #530](https://github.com/humanpred/pknca/discussions/530), where a user asked how sparse sampling groups samples when the concentration formula has several grouping variables — e.g. `conc~time | matrix + drug + usubjid / analyte`. The vignette didn't explain the behavior, leaving it unclear whether samples are combined by `usubjid`, by a single grouping variable, or by the full combination.

The answer (and the actual behavior in the code) is that sparse parameters pool **all subjects that share the same concentration grouping variables with the subject column removed** — so the example above pools by `matrix + drug + analyte`.

## Changes

- **`vignettes/v04-sparse.Rmd`** — New section "How Subjects Are Grouped for Sparse Calculations" that:
  - explains sparse parameters are computed from the *pooled* samples of every subject in a group (vs. per-subject for dense PK);
  - states the rule: groups are the `PKNCAconc()` formula's grouping variables with the subject column removed;
  - walks through the exact multi-variable example from the discussion, showing `usubjid` is the subject and pooling is therefore by `matrix + drug + analyte` together — not by `usubjid` separately, and not by any single variable alone;
  - notes that all subjects in a group must share the same dosing, or PKNCA errors.
- **`NEWS.md`** — Entry under `## Improvements` referencing #530.

## Verification

- Claims checked against the grouping code: `setdiff(group_cols_selected, subject)` in `R/prepare_data.R`, subject default in `R/class-PKNCAconc.R`, and the shared-dosing check in `R/prepare_data.R`.
- `spelling::spell_check_files()` on the vignette: no errors.
- Vignette renders to HTML cleanly.

Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)