### PR TITLE
docs: add User Guide navbar link to pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,12 @@
-url: http://humanpred.github.io/pknca/
+url: https://humanpred.github.io/pknca/
 template:
   bootstrap: 5
 
+navbar:
+  structure:
+    left:  [intro, reference, articles, tutorials, news]
+    right: [user_guide, search, github]
+  components:
+    user_guide:
+      text: User Guide
+      href: https://humanpred.github.io/pknca-book/


### PR DESCRIPTION
Link the pkgdown function-reference site to the new Quarto user-guide book at https://humanpred.github.io/pknca-book/ via a navbar entry (layer 2 of the three-layer docs structure). Also upgrade the site `url` from http to https, which github.io requires.