### PR TITLE
Wire lloq from PKNCAconc through to the Tobit half-life method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,12 @@ the dosing including dose amount and route.
 
 # New features
 
+* `PKNCAconc()` gains an `lloq` argument (a column name or a numeric scalar) that
+  is passed through to `pk.calc.half.life()`.  This wires the lower limit of
+  quantification through a full `pk.nca()` run so the Tobit half-life method
+  (`hl_method = "tobit"`, set via `PKNCAdata(options = list(hl_method = "tobit"))`)
+  works end-to-end instead of failing because no `lloq` was available.
+
 * Added sparse AUMC function and five sparse AUC parameters (cl.sparse.last, kel.sparse.last, mrt.ivint.last, vss.sparse.last, vz.sparse.last)
 
 * New IV dosing AUMC parameters with C0 back-extrapolation (`aumciv*`)

--- a/R/class-PKNCAconc.R
+++ b/R/class-PKNCAconc.R
@@ -33,6 +33,12 @@
 #'   or to include for the half-life (using specifically those points and
 #'   bypassing automatic curve-stripping point selection).  See the "Half-Life
 #'   Calculation" vignette for more details on the use of these arguments.
+#' @param lloq (optional) The lower limit of quantification used by the Tobit
+#'   half-life method (`hl_method = "tobit"`).  Either the name of a column in
+#'   `data` giving the per-observation LLOQ or a numeric scalar applied to all
+#'   observations.  When provided, it is passed through to
+#'   [pk.calc.half.life()].  See the "Half-Life Calculation with Tobit
+#'   Regression" vignette for more details.
 #' @param sparse Are the concentration-time data sparse PK (commonly used in
 #'   small nonclinical species or with terminal or difficult sampling) or dense
 #'   PK (commonly used in clinical studies or larger nonclinical species)?
@@ -63,7 +69,7 @@ PKNCAconc.tbl_df <- function(data, ...) {
 #' @export
 PKNCAconc.data.frame <- function(data, formula, subject,
                                  time.nominal, exclude = NULL, duration, volume,
-                                 exclude_half.life, include_half.life, sparse = FALSE, ...,
+                                 exclude_half.life, include_half.life, lloq, sparse = FALSE, ...,
                                  concu = NULL, amountu = NULL, timeu = NULL,
                                  concu_pref = NULL, amountu_pref = NULL, timeu_pref = NULL) {
   # The data must have... data
@@ -179,6 +185,12 @@ PKNCAconc.data.frame <- function(data, formula, subject,
       setAttributeColumn(object=ret,
                          attr_name="include_half.life",
                          col_name=include_half.life)
+  }
+  if (!missing(lloq)) {
+    ret <- setAttributeColumn(object=ret, attr_name="lloq", col_or_value=lloq)
+    if (!is.numeric(getAttributeColumn(object=ret, attr_name="lloq")[[1]])) {
+      stop("lloq must be numeric")
+    }
   }
 
   # Unit handling

--- a/R/pk.calc.all.R
+++ b/R/pk.calc.all.R
@@ -279,6 +279,9 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
         args$exclude_half.life <- conc_data_interval$exclude_half.life
         uses_exclude_hl <- !is.null(args$exclude_half.life) && !all(is.na(args$exclude_half.life))
       }
+      if ("lloq" %in% names(conc_data_interval)) {
+        args$lloq <- conc_data_interval$lloq
+      }
       if (uses_include_hl && uses_exclude_hl) {
         stop("Cannot both include and exclude half-life points for the same interval")
       }
@@ -353,6 +356,9 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
 #'   half-life point selection will occur.
 #' @param exclude_half.life An optional boolean vector of the concentration
 #'   measurements to exclude from the half-life calculation.
+#' @param lloq An optional scalar or vector (the same length as `conc`) with the
+#'   lower limit of quantification passed to [pk.calc.half.life()] for the Tobit
+#'   half-life method.
 #' @param subject Subject identifiers (used for sparse calculations)
 #' @param sparse Should only sparse calculations be performed (TRUE) or only
 #'   dense calculations (FALSE)?
@@ -366,7 +372,7 @@ pk.nca.interval <- function(conc, time, volume, duration.conc,
                             conc.group=NULL, time.group=NULL, volume.group=NULL, duration.conc.group=NULL,
                             dose.group=NULL, time.dose.group=NULL, duration.dose.group=NULL, route.group=NULL,
                             impute_method=NA_character_,
-                            include_half.life=NULL, exclude_half.life=NULL,
+                            include_half.life=NULL, exclude_half.life=NULL, lloq=NULL,
                             subject, sparse, interval, options=list()) {
   if (!is.data.frame(interval)) {
     stop("Please report a bug.  Interval must be a data.frame")
@@ -469,6 +475,8 @@ pk.nca.interval <- function(conc, time, volume, duration.conc,
           call_args[[arg_formal]] <- route.group
         } else if (arg_mapped == "subject") {
           call_args[[arg_formal]] <- subject
+        } else if (arg_mapped == "lloq") {
+          call_args[[arg_formal]] <- lloq
         } else if (arg_mapped %in% c("start", "end")) {
           # Provide the start and end of the interval if they are requested
           call_args[[arg_formal]] <- interval[[arg_mapped]]
@@ -500,15 +508,21 @@ pk.nca.interval <- function(conc, time, volume, duration.conc,
       if (n %in% "half.life") {
         uses_include_hl <- !is.null(include_half.life) && !all(is.na(include_half.life))
         uses_exclude_hl <- !is.null(exclude_half.life) && !all(is.na(exclude_half.life))
+        # Keep a per-observation lloq aligned with conc when points are manually
+        # included or excluded (a scalar lloq is broadcast by pk.calc.half.life).
+        lloq_is_vector <-
+          !is.null(call_args$lloq) && length(call_args$lloq) == length(call_args$conc)
         if (uses_include_hl) {
           include_tf <- include_half.life %in% TRUE
           call_args$conc <- call_args$conc[include_tf]
           call_args$time <- call_args$time[include_tf]
+          if (lloq_is_vector) call_args$lloq <- call_args$lloq[include_tf]
           call_args$manually.selected.points <- TRUE
         } else if (uses_exclude_hl) {
           exclude_tf <- exclude_half.life %in% TRUE
           call_args$conc <- call_args$conc[!exclude_tf]
           call_args$time <- call_args$time[!exclude_tf]
+          if (lloq_is_vector) call_args$lloq <- call_args$lloq[!exclude_tf]
         }
       }
       # Do the calculation

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -137,7 +137,8 @@ prepare_PKNCAconc <- function(.dat, extra_cols = character()) {
       volume=.dat$columns$volume,
       duration=.dat$columns$duration,
       include_half.life=.dat$columns$include_half.life,
-      exclude_half.life=.dat$columns$exclude_half.life
+      exclude_half.life=.dat$columns$exclude_half.life,
+      lloq=.dat$columns$lloq
     )
   needed_cols <- append(needed_cols, stats::setNames(nm = extra_cols))
   data_name <- getDataName(.dat)

--- a/man/PKNCAconc.Rd
+++ b/man/PKNCAconc.Rd
@@ -23,6 +23,7 @@ PKNCAconc(data, ...)
   volume,
   exclude_half.life,
   include_half.life,
+  lloq,
   sparse = FALSE,
   ...,
   concu = NULL,
@@ -76,6 +77,13 @@ name in the dataset of the points to exclude from the half-life calculation
 or to include for the half-life (using specifically those points and
 bypassing automatic curve-stripping point selection).  See the "Half-Life
 Calculation" vignette for more details on the use of these arguments.}
+
+\item{lloq}{(optional) The lower limit of quantification used by the Tobit
+half-life method (\code{hl_method = "tobit"}).  Either the name of a column in
+\code{data} giving the per-observation LLOQ or a numeric scalar applied to all
+observations.  When provided, it is passed through to
+\code{\link[=pk.calc.half.life]{pk.calc.half.life()}}.  See the "Half-Life Calculation with Tobit
+Regression" vignette for more details.}
 
 \item{sparse}{Are the concentration-time data sparse PK (commonly used in
 small nonclinical species or with terminal or difficult sampling) or dense

--- a/man/pk.nca.interval.Rd
+++ b/man/pk.nca.interval.Rd
@@ -24,6 +24,7 @@ pk.nca.interval(
   impute_method = NA_character_,
   include_half.life = NULL,
   exclude_half.life = NULL,
+  lloq = NULL,
   subject,
   sparse,
   interval,
@@ -75,6 +76,10 @@ half-life point selection will occur.}
 
 \item{exclude_half.life}{An optional boolean vector of the concentration
 measurements to exclude from the half-life calculation.}
+
+\item{lloq}{An optional scalar or vector (the same length as \code{conc}) with the
+lower limit of quantification passed to \code{\link[=pk.calc.half.life]{pk.calc.half.life()}} for the Tobit
+half-life method.}
 
 \item{subject}{Subject identifiers (used for sparse calculations)}
 

--- a/tests/testthat/test-class-PKNCAconc.R
+++ b/tests/testthat/test-class-PKNCAconc.R
@@ -639,3 +639,32 @@ test_that("PKNCAconc units (#336)", {
     structure("amountu_x", unit_type = "column")
   )
 })
+
+test_that("PKNCAconc lloq argument is stored and validated (scalar and column)", {
+  tmp.conc <- generate.conc(nsub = 2, ntreat = 1, time.points = 0:6)
+
+  # A scalar value materialises an "lloq" column filled with that value
+  o_scalar <- PKNCAconc(tmp.conc, conc ~ time | ID, lloq = 0.5)
+  expect_equal(o_scalar$columns$lloq, "lloq")
+  expect_equal(o_scalar$data$lloq, rep(0.5, nrow(tmp.conc)))
+
+  # A column name is used directly
+  tmp.conc.col <- tmp.conc
+  tmp.conc.col$assay_lloq <- 0.25
+  o_col <- PKNCAconc(tmp.conc.col, conc ~ time | ID, lloq = "assay_lloq")
+  expect_equal(o_col$columns$lloq, "assay_lloq")
+  expect_equal(o_col$data$assay_lloq, rep(0.25, nrow(tmp.conc.col)))
+
+  # A non-numeric lloq column is rejected
+  tmp.conc.bad <- tmp.conc
+  tmp.conc.bad$bad_lloq <- "x"
+  expect_error(
+    PKNCAconc(tmp.conc.bad, conc ~ time | ID, lloq = "bad_lloq"),
+    regexp = "lloq must be numeric"
+  )
+
+  # Without lloq, no lloq column or attribute is added
+  o_none <- PKNCAconc(tmp.conc, conc ~ time | ID)
+  expect_null(o_none$columns$lloq)
+  expect_false("lloq" %in% names(o_none$data))
+})

--- a/tests/testthat/test-half.life.R
+++ b/tests/testthat/test-half.life.R
@@ -763,6 +763,60 @@ test_that("pk.calc.half.life hl_method='tobit' global option is respected", {
   )
 })
 
+test_that("pk.nca() wires the PKNCAconc lloq through to the Tobit half-life", {
+  lloq <- 1.0
+  conc_true <- c(10, 5, 2.5, 1.25, 0.5, 0.2)
+  d_conc <- data.frame(
+    subject = 1L,
+    time = c(0, 1, 2, 3, 4, 5),
+    # Observations below the LLOQ are reported as zero
+    conc = ifelse(conc_true < lloq, 0, conc_true)
+  )
+  d_dose <- data.frame(subject = 1L, time = 0, dose = 100)
+  o_conc <- PKNCAconc(d_conc, conc ~ time | subject, lloq = lloq)
+  o_dose <- PKNCAdose(d_dose, dose ~ time | subject)
+  o_data <- PKNCAdata(
+    o_conc, o_dose,
+    intervals = data.frame(start = 0, end = Inf, half.life = TRUE),
+    options = list(hl_method = "tobit", allow.tmax.in.half.life = TRUE, min.hl.points = 3)
+  )
+  res <- as.data.frame(suppressMessages(pk.nca(o_data)))
+  # The full-pipeline result must match a direct call with the same lloq
+  direct <- pk.calc.half.life(
+    conc = d_conc$conc, time = d_conc$time, lloq = lloq,
+    hl_method = "tobit", allow.tmax.in.half.life = TRUE, min.hl.points = 3
+  )
+  expect_equal(res$PPORRES[res$PPTESTCD == "half.life"], direct$half.life)
+  expect_equal(res$PPORRES[res$PPTESTCD == "lambda.z"], direct$lambda.z)
+  # BLQ points were retained in the fit (the purpose of the Tobit method)
+  expect_equal(res$PPORRES[res$PPTESTCD == "lambda.z.n.points_blq"], 2)
+})
+
+test_that("pk.nca() accepts a per-observation lloq column for the Tobit half-life", {
+  lloq <- 1.0
+  conc_true <- c(10, 5, 2.5, 1.25, 0.5, 0.2)
+  d_conc <- data.frame(
+    subject = 1L,
+    time = c(0, 1, 2, 3, 4, 5),
+    conc = ifelse(conc_true < lloq, 0, conc_true),
+    my_lloq = lloq
+  )
+  d_dose <- data.frame(subject = 1L, time = 0, dose = 100)
+  o_conc <- PKNCAconc(d_conc, conc ~ time | subject, lloq = "my_lloq")
+  expect_equal(o_conc$columns$lloq, "my_lloq")
+  o_data <- PKNCAdata(
+    o_conc, PKNCAdose(d_dose, dose ~ time | subject),
+    intervals = data.frame(start = 0, end = Inf, half.life = TRUE),
+    options = list(hl_method = "tobit", allow.tmax.in.half.life = TRUE, min.hl.points = 3)
+  )
+  res <- as.data.frame(suppressMessages(pk.nca(o_data)))
+  direct <- pk.calc.half.life(
+    conc = d_conc$conc, time = d_conc$time, lloq = lloq,
+    hl_method = "tobit", allow.tmax.in.half.life = TRUE, min.hl.points = 3
+  )
+  expect_equal(res$PPORRES[res$PPTESTCD == "half.life"], direct$half.life)
+})
+
 test_that("pk.calc.half.life log-linear result is unaffected by Tobit additions", {
   # Existing log-linear behaviour should be completely unchanged
   result <- pk.calc.half.life(

--- a/vignettes/v06-half-life-calculation-tobit.Rmd
+++ b/vignettes/v06-half-life-calculation-tobit.Rmd
@@ -213,22 +213,32 @@ PKNCA.options(default = TRUE)
 
 ## Full NCA workflow with PKNCAdata
 
-The `lloq` argument can be passed through the interval calculation via the
-`options` list when running a full NCA.
+When running a full NCA, provide the LLOQ through the `lloq` argument to
+`PKNCAconc()`.  It is then automatically passed to `pk.calc.half.life()` when the
+Tobit method is selected (here via the `hl_method` option).  `lloq` may be a
+numeric scalar applied to all observations or the name of a column in the
+concentration data giving a per-observation LLOQ.
 
-```{r full-nca, eval=FALSE}
-# Suppose d_conc is your concentration data frame with columns
-# subject, time, conc, and your LLOQ is 1.0
+```{r full-nca}
+lloq <- 1.0
+conc_true <- c(10, 5, 2.5, 1.25, 0.5, 0.2)
+d_conc <- data.frame(
+  subject = 1L,
+  time = c(0, 1, 2, 3, 4, 5),
+  # Observations below the LLOQ are reported as zero
+  conc = ifelse(conc_true < lloq, 0, conc_true)
+)
+d_dose <- data.frame(subject = 1L, time = 0, dose = 100)
 
-o_conc <- PKNCAconc(d_conc, conc ~ time | subject)
+o_conc <- PKNCAconc(d_conc, conc ~ time | subject, lloq = lloq)
 o_dose <- PKNCAdose(d_dose, dose ~ time | subject)
 o_data <- PKNCAdata(
   o_conc, o_dose,
   intervals = data.frame(start = 0, end = Inf, half.life = TRUE),
-  options = list(hl_method = "tobit")
+  options = list(hl_method = "tobit", allow.tmax.in.half.life = TRUE, min.hl.points = 3)
 )
-# Note: lloq must be provided per-subject in the concentration data or
-# as a scalar in the options when using the Tobit method in pk.nca().
+o_result <- pk.nca(o_data)
+as.data.frame(o_result)[, c("PPTESTCD", "PPORRES")]
 ```
 
 ## Controlling Tobit point selection


### PR DESCRIPTION
## Problem

When `hl_method = "tobit"` is set via `PKNCAdata(options = list(hl_method = "tobit"))`,
the `lloq` value was not wired through to `pk.calc.half.life()`, so a full `pk.nca()`
run terminated with a generic "Please report a bug" error instead of computing the
half-life. There was no way to supply the lower limit of quantification that the Tobit
method requires. (Bug documented in the pknca-book `BUILDING_SETUP.md` "Known bug" section.)

## Fix

Add an `lloq` argument to `PKNCAconc()` — either the name of a column in the data
(per-observation LLOQ) or a numeric scalar applied to all observations — and thread it
through the calculation pipeline to `pk.calc.half.life()`, mirroring the existing
`volume` / `exclude_half.life` wiring:

- **`PKNCAconc()`** stores `lloq` via `setAttributeColumn()` with a numeric check.
- **`prepare_PKNCAconc()`** materializes the `lloq` column into the per-interval conc data.
- **`pk.nca.interval()`** maps `lloq` to the half-life function and keeps it aligned with
  `conc` when half-life points are manually included/excluded (a scalar is broadcast).

When `lloq` is omitted, behavior is unchanged (the column/attribute is not added).

## Docs & tests

- Replaced the non-working `eval = FALSE` "Full NCA workflow" example in the Tobit
  vignette with a runnable one using `PKNCAconc(..., lloq = ...)`.
- Added `NEWS.md` entry and regenerated `man/`.
- New tests: end-to-end `pk.nca()` Tobit runs (scalar lloq and per-observation column,
  both matched against a direct `pk.calc.half.life()` call) plus `PKNCAconc` construction
  and numeric-validation tests.

## Verification

- `devtools::test()`: PASS 2587, FAIL 0, ERROR 0
- `devtools::check()`: 0 errors, 0 warnings (2 pre-existing notes unrelated to this change)
- Tobit vignette knits and shows the half-life computed with BLQ points retained.