### PR TITLE
chore: ignore .claude/worktrees in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ inst/doc
 Rprof.out
 .Rhistory
 /revdep
+.claude/worktrees/


### PR DESCRIPTION
Worktrees created under `.claude/worktrees/` (e.g. Claude Code task
worktrees) appear as untracked entries in the main checkout, cluttering
`git status`. This adds `.claude/worktrees/` to `.gitignore` so they're
ignored.

`.claude` is already excluded from the built R package via
`.Rbuildignore` (`^\.claude$`), so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)