### PR TITLE
docs: deduplicate include/exclude_half.life via @inheritParams

### DIFF
--- a/R/class-PKNCAconc.R
+++ b/R/class-PKNCAconc.R
@@ -27,17 +27,19 @@
 #'   used for urine or feces measurements.
 #' @param duration (optional) The duration of collection as is typically used
 #'   for concentration measurements in urine or feces.
-#' @param exclude_half.life,include_half.life A character scalar for the column
-#'   name in the dataset.  `exclude_half.life` names points to drop; automatic
-#'   curve-stripping point selection is still performed on the remaining
-#'   (non-excluded) points and is not bypassed.  `include_half.life` names the
-#'   exact points to use, bypassing automatic curve-stripping point selection.
-#'   Each value is `TRUE`, `FALSE`, or `NA` (undefined); a column is treated as
-#'   "in use" for an interval unless it is entirely `NA`, so leave it `NA`
-#'   (rather than `FALSE`) where the mechanism should not apply.  Only one of
-#'   `exclude_half.life` and `include_half.life` may be in use for a given
-#'   interval.  See the "Half-Life Calculation" vignette for more details on the
-#'   use of these arguments.
+#' @param exclude_half.life,include_half.life Manual half-life point selection,
+#'   given as a logical value per concentration measurement (or, in
+#'   [PKNCAconc()], the name of such a column in the data).  `exclude_half.life`
+#'   drops the flagged points; automatic curve-stripping point selection is
+#'   still performed on the remaining (non-excluded) points and is not bypassed.
+#'   `include_half.life` names the exact points to use, bypassing automatic
+#'   curve-stripping point selection.  Each value is `TRUE`, `FALSE`, or `NA`
+#'   (undefined); the column/vector is treated as "in use" for an interval
+#'   unless it is entirely `NA` (so an all-`FALSE` column still counts as in
+#'   use), so leave it `NA` (rather than `FALSE`) where the mechanism should not
+#'   apply.  Only one of `exclude_half.life` and `include_half.life` may be in
+#'   use for a given interval.  See the "Half-Life Calculation" vignette for
+#'   more details on the use of these arguments.
 #' @param lloq (optional) The lower limit of quantification used by the Tobit
 #'   half-life method (`hl_method = "tobit"`).  Either the name of a column in
 #'   `data` giving the per-observation LLOQ or a numeric scalar applied to all

--- a/R/pk.calc.all.R
+++ b/R/pk.calc.all.R
@@ -326,6 +326,7 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
 #'
 #' @inheritParams assert_conc_time
 #' @inheritParams PKNCA.choose.option
+#' @inheritParams PKNCAconc
 #' @param conc.group All concentrations measured for the group
 #' @param time.group Time of all concentrations measured for the group
 #' @param volume,volume.group The volume (or mass) of the concentration
@@ -351,20 +352,6 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
 #' @param impute_method The method to use for imputation as a character string
 #' @param interval One row of an interval definition (see
 #'   [check.interval.specification()] for how to define the interval.
-#' @param include_half.life An optional logical vector (one value per
-#'   concentration measurement) naming the points to use for the half-life. If
-#'   in use, automatic curve-stripping point selection is bypassed and exactly
-#'   the `TRUE` points are used for the half-life regression. `TRUE` uses the
-#'   point, `FALSE` does not, and `NA` is undefined; the vector is "in use" for
-#'   the interval unless it is entirely `NA` (so an all-`FALSE` vector still
-#'   counts as in use). At most one of `include_half.life` and
-#'   `exclude_half.life` may be in use for the same interval.
-#' @param exclude_half.life An optional logical vector (one value per
-#'   concentration measurement) naming points to drop before point selection.
-#'   Automatic curve-stripping point selection is still performed (it is not
-#'   bypassed) on the remaining, non-excluded points. `TRUE` excludes the point,
-#'   `FALSE` does not, and `NA` is undefined; the "in use" rule is the same as
-#'   for `include_half.life`.
 #' @param lloq An optional scalar or vector (the same length as `conc`) with the
 #'   lower limit of quantification passed to [pk.calc.half.life()] for the Tobit
 #'   half-life method.

--- a/man/PKNCAconc.Rd
+++ b/man/PKNCAconc.Rd
@@ -71,17 +71,19 @@ for concentration measurements in urine or feces.}
 \item{volume}{(optional) The volume (or mass) of collection as is typically
 used for urine or feces measurements.}
 
-\item{exclude_half.life, include_half.life}{A character scalar for the column
-name in the dataset.  \code{exclude_half.life} names points to drop; automatic
-curve-stripping point selection is still performed on the remaining
-(non-excluded) points and is not bypassed.  \code{include_half.life} names the
-exact points to use, bypassing automatic curve-stripping point selection.
-Each value is \code{TRUE}, \code{FALSE}, or \code{NA} (undefined); a column is treated as
-"in use" for an interval unless it is entirely \code{NA}, so leave it \code{NA}
-(rather than \code{FALSE}) where the mechanism should not apply.  Only one of
-\code{exclude_half.life} and \code{include_half.life} may be in use for a given
-interval.  See the "Half-Life Calculation" vignette for more details on the
-use of these arguments.}
+\item{exclude_half.life, include_half.life}{Manual half-life point selection,
+given as a logical value per concentration measurement (or, in
+\code{\link[=PKNCAconc]{PKNCAconc()}}, the name of such a column in the data).  \code{exclude_half.life}
+drops the flagged points; automatic curve-stripping point selection is
+still performed on the remaining (non-excluded) points and is not bypassed.
+\code{include_half.life} names the exact points to use, bypassing automatic
+curve-stripping point selection.  Each value is \code{TRUE}, \code{FALSE}, or \code{NA}
+(undefined); the column/vector is treated as "in use" for an interval
+unless it is entirely \code{NA} (so an all-\code{FALSE} column still counts as in
+use), so leave it \code{NA} (rather than \code{FALSE}) where the mechanism should not
+apply.  Only one of \code{exclude_half.life} and \code{include_half.life} may be in
+use for a given interval.  See the "Half-Life Calculation" vignette for
+more details on the use of these arguments.}
 
 \item{lloq}{(optional) The lower limit of quantification used by the Tobit
 half-life method (\code{hl_method = "tobit"}).  Either the name of a column in

--- a/man/pk.nca.interval.Rd
+++ b/man/pk.nca.interval.Rd
@@ -70,21 +70,19 @@ bolus and nonzero for intravascular infusion)}
 
 \item{impute_method}{The method to use for imputation as a character string}
 
-\item{include_half.life}{An optional logical vector (one value per
-concentration measurement) naming the points to use for the half-life. If
-in use, automatic curve-stripping point selection is bypassed and exactly
-the \code{TRUE} points are used for the half-life regression. \code{TRUE} uses the
-point, \code{FALSE} does not, and \code{NA} is undefined; the vector is "in use" for
-the interval unless it is entirely \code{NA} (so an all-\code{FALSE} vector still
-counts as in use). At most one of \code{include_half.life} and
-\code{exclude_half.life} may be in use for the same interval.}
-
-\item{exclude_half.life}{An optional logical vector (one value per
-concentration measurement) naming points to drop before point selection.
-Automatic curve-stripping point selection is still performed (it is not
-bypassed) on the remaining, non-excluded points. \code{TRUE} excludes the point,
-\code{FALSE} does not, and \code{NA} is undefined; the "in use" rule is the same as
-for \code{include_half.life}.}
+\item{exclude_half.life, include_half.life}{Manual half-life point selection,
+given as a logical value per concentration measurement (or, in
+\code{\link[=PKNCAconc]{PKNCAconc()}}, the name of such a column in the data).  \code{exclude_half.life}
+drops the flagged points; automatic curve-stripping point selection is
+still performed on the remaining (non-excluded) points and is not bypassed.
+\code{include_half.life} names the exact points to use, bypassing automatic
+curve-stripping point selection.  Each value is \code{TRUE}, \code{FALSE}, or \code{NA}
+(undefined); the column/vector is treated as "in use" for an interval
+unless it is entirely \code{NA} (so an all-\code{FALSE} column still counts as in
+use), so leave it \code{NA} (rather than \code{FALSE}) where the mechanism should not
+apply.  Only one of \code{exclude_half.life} and \code{include_half.life} may be in
+use for a given interval.  See the "Half-Life Calculation" vignette for
+more details on the use of these arguments.}
 
 \item{lloq}{An optional scalar or vector (the same length as \code{conc}) with the
 lower limit of quantification passed to \code{\link[=pk.calc.half.life]{pk.calc.half.life()}} for the Tobit


### PR DESCRIPTION
Document exclude_half.life/include_half.life in a single location (PKNCAconc) and inherit them in pk.nca.interval via @inheritParams, so the description lives in one place. The shared text is phrased to cover both forms: a logical column name in PKNCAconc(), or the logical vector itself. Regenerate man pages (the two topics now share identical argument text).