### PR TITLE
Add conc.include.end option to exclude interval end point

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,13 @@ the dosing including dose amount and route.
 
 # Development version
 
+* New `conc.include.end` option (default `TRUE`) controls whether a
+  concentration measured exactly at the end of an interval is included in that
+  interval's calculations.  Set it to `FALSE` (e.g.
+  `PKNCAdata(options = list(conc.include.end = FALSE))`) to treat intervals as
+  half-open on the right (`[start, end)`) so a point at `time == end` (such as an
+  imputed C0 for the next dose) is excluded.  The default preserves existing
+  behavior.
 * Bug fix: `pk.nca()` no longer errors on unsorted concentration-time data.
   Group-level concentration data are now sorted by time before calculation, so
   parameters that use the full group (e.g. `aucint.all` and the other `aucint*`

--- a/R/PKNCA.options.R
+++ b/R/PKNCA.options.R
@@ -209,7 +209,31 @@
     }
     x
   },
-
+  conc.include.end=function(x, default=FALSE, description=FALSE) {
+    if (description)
+      return(paste(
+        "Should a concentration measured exactly at the end of an interval",
+        "be included in that interval's calculations?  If 'TRUE' (the",
+        "default), intervals are closed on the right ('[start, end]').  If",
+        "'FALSE', intervals are half-open on the right ('[start, end)') so a",
+        "point at 'time == end' (for example an imputed C0 for the next dose)",
+        "is excluded."))
+    if (default)
+      return(TRUE)
+    if (length(x) != 1)
+      stop("conc.include.end must be a scalar")
+    if (is.na(x))
+      stop("conc.include.end may not be NA")
+    if (!is.logical(x)) {
+      x <- as.logical(x)
+      if (is.na(x)) {
+        stop("Could not convert conc.include.end to a logical value")
+      } else {
+        warning("Converting conc.include.end to a logical value: ", x)
+      }
+    }
+    x
+  },
   keep_interval_cols = function(x, default = FALSE, description = FALSE) {
     if (description)
       return("What additional columns from the intervals should be kept in the results?")

--- a/R/pk.calc.all.R
+++ b/R/pk.calc.all.R
@@ -210,8 +210,14 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
   for (i in seq_len(nrow(data_intervals))) {
     current_interval <- data_intervals[i, , drop=FALSE]
     has_calc_sparse_dense <- any_sparse_dense_in_interval(current_interval, sparse=sparse)
-    # Choose only times between the start and end.
-    conc_data_interval <- filter_interval(data_conc, start=data_intervals$start[i], end=data_intervals$end[i])
+    # Choose only times between the start and end
+    # conc.include.end option allows excluding end point intervals
+    conc_data_interval <- filter_interval(
+      data_conc,
+      start=data_intervals$start[i],
+      end=data_intervals$end[i],
+      include_end=options$conc.include.end
+    )
     # Sort the data in time order
     conc_data_interval <- conc_data_interval[order(conc_data_interval$time),]
     NA_data_dose_ <- data.frame(dose=NA_real_, time=NA_real_, duration=NA_real_, route=NA_real_)

--- a/tests/testthat/test-PKNCA.options.R
+++ b/tests/testthat/test-PKNCA.options.R
@@ -68,7 +68,7 @@ test_that("PKNCA.options", {
       first.tmax = TRUE,
       first.tmin = TRUE,
       allow.tmax.in.half.life = FALSE,
-      conc.includde.end = TRUE,
+      conc.include.end = TRUE,
       keep_interval_cols = NULL,
       min.hl.points = 3,
       min.span.ratio = 2,

--- a/tests/testthat/test-PKNCA.options.R
+++ b/tests/testthat/test-PKNCA.options.R
@@ -68,6 +68,7 @@ test_that("PKNCA.options", {
       first.tmax = TRUE,
       first.tmin = TRUE,
       allow.tmax.in.half.life = FALSE,
+      conc.includde.end = TRUE,
       keep_interval_cols = NULL,
       min.hl.points = 3,
       min.span.ratio = 2,

--- a/tests/testthat/test-pk.calc.all.R
+++ b/tests/testthat/test-pk.calc.all.R
@@ -1096,3 +1096,81 @@ test_that("pk.nca sorts group data by time so unsorted input works (#568)", {
     )
   expect_equal(merged$PPORRES.uns, merged$PPORRES.srt)
 })
+
+
+test_that("filter_interval include_end controls the right boundary", {
+  d <- data.frame(time = c(0, 12, 24), conc = c(10, 5, 1))
+  # Closed interval (default): the point at time == end is kept
+  incl <- PKNCA:::filter_interval(d, start = 0, end = 24)
+  expect_equal(incl$time, c(0, 12, 24),
+               info = "include_end=TRUE keeps the point at time == end")
+  # Half-open interval: the point at time == end is dropped
+  excl <- PKNCA:::filter_interval(d, start = 0, end = 24, include_end = FALSE)
+  expect_equal(excl$time, c(0, 12),
+               info = "include_end=FALSE drops the point at time == end")
+})
+
+test_that("conc.include.end option controls interval end point in pk.nca", {
+  # Single subject, one profile.  A spurious high value sits exactly at the
+  # interval end (mimicking an imputed C0 for a subsequent dose).  With the
+  # default (closed interval) it inflates auclast; with conc.include.end=FALSE
+  # it is excluded and auclast returns to the value from the clean profile.
+  clean <- data.frame(
+    ID = 1,
+    time = c(0, 1, 2, 4, 8, 12, 24),
+    conc = c(10, 8, 6.5, 4, 2, 1, 0.5)
+  )
+  spiked <- clean
+  spiked$conc[spiked$time == 24] <- 100  # boundary point becomes a large spike
+  
+  dose <- data.frame(ID = 1, time = 0, dose = 100)
+  intervals <- data.frame(start = 0, end = 24, auclast = TRUE)
+  
+  make_result <- function(conc_df, include_end) {
+    o_conc <- PKNCAconc(conc_df, formula = conc~time|ID)
+    o_dose <- PKNCAdose(dose, formula = dose~time|ID, route = "intravascular")
+    o_data <- PKNCAdata(
+      o_conc, o_dose, intervals = intervals,
+      options = list(conc.include.end = include_end)
+    )
+    res <- as.data.frame(pk.nca(o_data))
+    res$PPORRES[res$PPTESTCD == "auclast"]
+  }
+  
+  auclast_clean <- make_result(clean, TRUE)
+  auclast_spiked_incl <- make_result(spiked, TRUE)
+  auclast_spiked_excl <- make_result(spiked, FALSE)
+  
+  expect_gt(auclast_spiked_incl, auclast_clean * 2)
+  expect_equal(
+    auclast_spiked_excl,
+    make_result(clean[clean$time < 24, , drop = FALSE], TRUE),
+    info = "Excluding the end point matches integrating without that point"
+  )
+})
+
+test_that("conc.include.end default preserves existing (closed interval) results", {
+  tmpconc <- generate.conc(2, 1, 0:24)
+  tmpdose <- generate.dose(tmpconc)
+  myconc <- PKNCAconc(tmpconc, formula=conc~time|treatment+ID)
+  mydose <- PKNCAdose(tmpdose, formula=dose~time|treatment+ID)
+  base_result <- pk.nca(PKNCAdata(myconc, mydose))
+  opt_result <-
+    pk.nca(PKNCAdata(myconc, mydose, options = list(conc.include.end = TRUE)))
+  expect_equal(base_result$result, opt_result$result,
+               info = "conc.include.end=TRUE is identical to the default behavior")
+})
+
+test_that("conc.include.end option validation", {
+  expect_true(PKNCA.options(name = "conc.include.end", value = TRUE, check = TRUE))
+  expect_false(PKNCA.options(name = "conc.include.end", value = FALSE, check = TRUE))
+  expect_error(
+    PKNCA.options(name = "conc.include.end", value = c(TRUE, FALSE), check = TRUE),
+    regexp = "conc.include.end must be a scalar"
+  )
+  expect_error(
+    PKNCA.options(name = "conc.include.end", value = NA, check = TRUE),
+    regexp = "conc.include.end may not be NA"
+  )
+})
+


### PR DESCRIPTION
Adds a global `conc.include.end` option (default `TRUE`) controlling whether a concentration measured exactly at `time == end` is included in an interval's calculations. Set it to `FALSE` for half-open intervals `[start, end)`.

Useful when a point at the interval boundary belongs to the next dose (e.g. an imputed C0) and wrongly inflates AUC/tmax for the current profile.

The internal `filter_interval()` already supported `include_end` (dose selection uses `include_end = FALSE`); this exposes it for concentrations via the options system.

- `R/PKNCA.options.R`: register `conc.include.end` (logical, validated)
- `R/pk.calc.all.R`: pass the option through at the concentration call site
- Tests: boundary behavior, end-to-end AUC effect, default-unchanged regression, option validation

Default preserves existing behavior.