### PR TITLE
Fix AUC to infinity subscript formatting in vignettes

### DIFF
--- a/vignettes/v05-auc-calculation-with-PKNCA.Rmd
+++ b/vignettes/v05-auc-calculation-with-PKNCA.Rmd
@@ -120,7 +120,7 @@ ggplot(my_conc,
 
 AUC~0-$\infty$~ is commonly used for single-dose data.  It calculates the AUC~0-last~ and then extrapolates to $\infty$ using the estimated half-life.  Two starting points are used to estimate from `tlast` to $\infty$, the observed or half-life predicted concentration at `tlast` (`clast.obs` and `clast.pred`).
 
-The two figures below illustrate the integration with AUC~0-$\infty$,obs~ and AUC~0-$\infty$,pred$.  The difference between the two figures is most evident at time=8 where there is a discontinuity in integration at `tlast` due to using `clast.pred` after that point and `clast.obs` before that point.  (To illustrate the integration differences, BLQ indicator shapes have been removed.  BLQ is handled identically to previous figures.)
+The two figures below illustrate the integration with AUC~0-$\infty$,obs~ and AUC~0-$\infty$,pred~.  The difference between the two figures is most evident at time=8 where there is a discontinuity in integration at `tlast` due to using `clast.pred` after that point and `clast.obs` before that point.  (To illustrate the integration differences, BLQ indicator shapes have been removed.  BLQ is handled identically to previous figures.)
 
 ```{r aucinf, fig.width=6}
 # Add one row to illustrate extrapolation beyond observed data

--- a/vignettes/v30-training-session.Rmd
+++ b/vignettes/v30-training-session.Rmd
@@ -996,7 +996,7 @@ as.data.frame(o_nca)
 
 ## PKNCA only calculates what is required, not every possible parameter (2 of 2) {.columns-2 .smaller}
 
-If you need AUC~0-\infty~, PKNCA will calculate other required parameters behind the scenes.
+If you need AUC~0-$\infty$~, PKNCA will calculate other required parameters behind the scenes.
 
 ```{r echo=TRUE}
 o_data <-


### PR DESCRIPTION
Two malformed AUC-to-infinity subscripts in the vignettes:

- `v05-auc-calculation-with-PKNCA.Rmd` (AUC to Infinity section): `AUC~0-$\infty$,pred$` closed the pandoc subscript with a stray `$` instead of `~`, rendering a literal dollar sign with no subscripting. Now matches its `AUC~0-$\infty$,obs~` sibling.
- `v30-training-session.Rmd`: `AUC~0-\infty~` was missing the `$...$` inline-math delimiters, rendering a literal `\infty` in the subscript.

Verified both corrected lines through pandoc; they now produce proper `<sub>` markup with the ∞ symbol. All other `AUC~...~` occurrences across the vignettes were scanned and are well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)