### PR TITLE
Regenerate documentation with roxygen2 8.0.0

### DIFF
--- a/man/assert_number_between.Rd
+++ b/man/assert_number_between.Rd
@@ -13,7 +13,7 @@ assert_number_between(
 )
 }
 \arguments{
-\item{x}{[any]\cr
+\item{x}{[\code{any}]\cr
 Object to check.}
 
 \item{...}{Passed to \code{assert_numeric_between()}}

--- a/man/assert_numeric_between.Rd
+++ b/man/assert_numeric_between.Rd
@@ -17,7 +17,7 @@ assert_numeric_between(
 )
 }
 \arguments{
-\item{x}{[any]\cr
+\item{x}{[\code{any}]\cr
 Object to check.}
 
 \item{any.missing}{[\code{logical(1)}]\cr

--- a/man/filter.PKNCAresults.Rd
+++ b/man/filter.PKNCAresults.Rd
@@ -18,14 +18,14 @@ lazy data frame (e.g. from dbplyr or dtplyr). See \emph{Methods}, below, for
 more details.}
 
 \item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> Expressions that
-return a logical value, and are defined in terms of the variables in
-\code{.data}. If multiple expressions are included, they are combined with the
-\code{&} operator. Only rows for which all conditions evaluate to \code{TRUE} are
-kept.}
+return a logical vector, defined in terms of the variables in \code{.data}. If
+multiple expressions are included, they are combined with the \code{&} operator.
+To combine expressions using \code{|} instead, wrap them in \code{\link[dplyr:when_any]{when_any()}}. Only
+rows for which all expressions evaluate to \code{TRUE} are kept (for \code{filter()})
+or dropped (for \code{filter_out()}).}
 
-\item{.preserve}{Relevant when the \code{.data} input is grouped.
-If \code{.preserve = FALSE} (the default), the grouping structure
-is recalculated based on the resulting data, otherwise the grouping is kept as is.}
+\item{.preserve}{Relevant when the \code{.data} input is grouped. If \code{.preserve = FALSE} (the default), the grouping structure is recalculated based on the
+resulting data, otherwise the grouping is kept as is.}
 }
 \description{
 dplyr filtering for PKNCA

--- a/man/group_by.PKNCAresults.Rd
+++ b/man/group_by.PKNCAresults.Rd
@@ -26,20 +26,16 @@
 lazy data frame (e.g. from dbplyr or dtplyr). See \emph{Methods}, below, for
 more details.}
 
-\item{...}{In \code{group_by()}, variables or computations to group by.
-Computations are always done on the ungrouped data frame.
-To perform computations on the grouped data, you need to use
-a separate \code{mutate()} step before the \code{group_by()}.
+\item{...}{<\code{\link[rlang:args_data_masking]{data-masking}}> In \code{group_by()},
+variables or computations to group by. Computations are always done on the
+ungrouped data frame. To perform computations on the grouped data, you need
+to use a separate \code{mutate()} step before the \code{group_by()}.
 Computations are not allowed in \code{nest_by()}.
 In \code{ungroup()}, variables to remove from the grouping.}
 
 \item{.add}{When \code{FALSE}, the default, \code{group_by()} will
 override existing groups. To add to the existing groups, use
-\code{.add = TRUE}.
-
-This argument was previously called \code{add}, but that prevented
-creating a new grouping variable called \code{add}, and conflicts with
-our naming conventions.}
+\code{.add = TRUE}.}
 
 \item{.drop}{Drop groups formed by factor levels that don't appear in the
 data? The default is \code{TRUE} except when \code{.data} has been previously


### PR DESCRIPTION
Regenerates the four man pages that had drifted from roxygen2 8.0.0 output (the package already declares `Config/roxygen2/version: 8.0.0`; later PRs touched `man/` with older toolchains):

- `assert_number_between.Rd`, `assert_numeric_between.Rd`: `[any]` → `[\code{any}]`
- `filter.PKNCAresults.Rd`, `group_by.PKNCAresults.Rd`: `@inheritParams` text refreshed from dplyr 1.2.1, including `filter_out()`/`when_any()` references (links resolve against CRAN dplyr >= 1.2.0)

`NAMESPACE` and `DESCRIPTION` are unchanged. Docs-focused `R CMD check` (no tests/vignettes): 0 errors, 0 warnings.

Note: roxygen2 8 also flags `AIC.list` as needing `@export`/`@exportS3Method`; left out of this PR since fixing it changes `NAMESPACE` (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)