### PR TITLE
chore: ignore R build and check artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,16 @@ Rprof.out
 .Rhistory
 /revdep
 .claude/worktrees/
+
+# R build and check artifacts
+*.Rcheck/
+/check/
+*.tar.gz
+*.tgz
+.RData
+.Rdata
+.Ruserdata
+.Rproj.user/
+src/*.o
+src/*.so
+src/*.dll


### PR DESCRIPTION
Adds the standard R CMD build/check outputs to `.gitignore`:

- `*.Rcheck/` and `/check/` — the latter is where `r-lib/actions/check-r-package` writes by default
- `*.tar.gz`, `*.tgz` — built source and binary packages
- `.RData`, `.Rdata`, `.Ruserdata` — session state
- `.Rproj.user/` — already in `.Rbuildignore`, now ignored by git too
- `src/*.{o,so,dll}` — compiled objects (PKNCA is pure R today; included for the standard set)

No currently-tracked file is shadowed by any of these patterns.