### PR TITLE
docs: regenerate with roxygen2 8.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,4 +48,4 @@ Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -288,19 +288,23 @@ export(time_calc)
 export(ungroup)
 export(var_sparse_auc)
 export(var_sparse_aumc)
-importFrom(dplyr,"%>%")
-importFrom(dplyr,filter)
-importFrom(dplyr,full_join)
-importFrom(dplyr,group_by)
-importFrom(dplyr,group_vars)
-importFrom(dplyr,inner_join)
-importFrom(dplyr,left_join)
-importFrom(dplyr,mutate)
-importFrom(dplyr,right_join)
-importFrom(dplyr,ungroup)
+importFrom(dplyr,
+  "%>%",
+  filter,
+  full_join,
+  group_by,
+  group_vars,
+  inner_join,
+  left_join,
+  mutate,
+  right_join,
+  ungroup
+)
 importFrom(lifecycle,deprecated)
 importFrom(nlme,getGroups)
 importFrom(rlang,.data)
-importFrom(stats,formula)
-importFrom(stats,model.frame)
-importFrom(stats,na.omit)
+importFrom(stats,
+  formula,
+  model.frame,
+  na.omit
+)


### PR DESCRIPTION
Config/roxygen2/version said 8.0.0 while contributors are now running 8.1.0, so every regeneration rewrote NAMESPACE's importFrom directives into 8.1.0's multi-line style and bumped the version field.  That churn appeared in unrelated pull requests and had to be reverted by hand each time; doing it once here stops that.

The change is formatting only.  Parsing both files with parseNamespaceFile() gives identical results: the same 16 imported package/symbol pairs, the same 178 exports, and the same 110 S3 methods.

S3method(AIC,list) is kept.  roxygen2 drops it on every run because R/AIC.list.R is marked @noRd, but removing it would stop AIC() dispatching on lists, which is a behavior change and not part of a formatting commit. It stays hand-maintained.

The dplyr-inherited pages (filter.PKNCAresults.Rd, group_by.PKNCAresults.Rd) are left alone.  Their @inheritParams text comes from the installed dplyr, and dplyr 1.2 wording references when_any() and filter_out() while DESCRIPTION allows dplyr (>= 1.1.0) -- regenerating them here would document functions a supported dplyr does not have and leave a dangling \link.