### PR TITLE
Finish the checkmate/rlang migration leftovers from #548

### DIFF
--- a/R/class-summary_PKNCAresults.R
+++ b/R/class-summary_PKNCAresults.R
@@ -488,15 +488,7 @@ summarize_PKNCAresults_parameter <- function(data, parameter, subject_col, inclu
 
   current_summary_instructions <- PKNCA.set.summary()[[parameter]]
   if (is.null(current_summary_instructions)) {
-    # nocov start
-    rlang::abort(
-      sprintf(
-        "No summary function is set for parameter %s. Please set it with PKNCA.set.summary and report this as a bug in PKNCA.",
-        parameter
-      ),
-      class = "pknca_error_no_summary_function"
-    )
-    # nocov end
+    rlang::abort(sprintf("No summary function is set for parameter %s. Please set it with PKNCA.set.summary and report this as a bug in PKNCA.", parameter), class = "pknca_error_no_summary_function")  # nocov
   }
 
   point <- current_summary_instructions$point(current_data[[number_col]])

--- a/R/interpolate.conc.R
+++ b/R/interpolate.conc.R
@@ -422,15 +422,7 @@ interp.extrap.conc.dose <- function(conc, time,
     TRUE~"unknown") # should never happen
   if (any(mask_unknown <- data_all$event %in% "unknown")) {
     # All events should be accounted for already
-    # nocov start
-    rlang::abort(
-      sprintf(
-        "Unknown event in interp.extrap.conc.dose at time(s): %s (Please report this as a bug)",
-        paste(unique(data_all$time[mask_unknown]), collapse = ", ")
-      ),
-      class = "pknca_error_internal_unknown_event"
-    )
-    # nocov end
+    rlang::abort(sprintf("Unknown event in interp.extrap.conc.dose at time(s): %s (Please report this as a bug)", paste(unique(data_all$time[mask_unknown]), collapse = ", ")), class = "pknca_error_internal_unknown_event")  # nocov
   }
   # Remove "output_only" from event_before and event_after
   simple_locf <- function(x, missing_val) {
@@ -475,15 +467,7 @@ interp.extrap.conc.dose <- function(conc, time,
   }
   if (any(mask_no_method <- is.na(data_all$method))) {
     # This should never happen, all eventualities should be covered
-    # nocov start
-    rlang::abort(
-      sprintf(
-        "No method for imputing concentration at time(s): %s",
-        paste(unique(data_all$time[mask_no_method]), collapse = ", ")
-      ),
-      class = "pknca_error_no_interp_method"
-    )
-    # nocov end
+    rlang::abort(sprintf("No method for imputing concentration at time(s): %s", paste(unique(data_all$time[mask_no_method]), collapse = ", ")), class = "pknca_error_no_interp_method")  # nocov
   }
   # Filter to the requested time points and output
   data_out <- data_all[data_all$out,,drop=FALSE]
@@ -511,17 +495,7 @@ iecd_impossible_select <- function(x) {
        x$event_after %in% c("conc_dose_iv_bolus_after", "dose_iv_bolus_after"))
 }
 iecd_impossible_value <- function(data_all, current_idx, ...) {
-  # nocov start
-  rlang::abort(
-    sprintf(
-      "Impossible combination requested for interp.extrap.conc.dose (please report this as a bug).  event_before: %s, event: %s, event_after: %s",
-      data_all$event_before[current_idx],
-      data_all$event[current_idx],
-      data_all$event_after[current_idx]
-    ),
-    class = "pknca_error_internal_impossible_event_combination"
-  )
-  # nocov end
+  rlang::abort(sprintf("Impossible combination requested for interp.extrap.conc.dose (please report this as a bug).  event_before: %s, event: %s, event_after: %s", data_all$event_before[current_idx], data_all$event[current_idx], data_all$event_after[current_idx]), class = "pknca_error_internal_impossible_event_combination")  # nocov
 }
 
 # Observed concentration ####

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -161,7 +161,7 @@ prepare_PKNCAconc <- function(.dat, extra_cols = character()) {
         group_cols_selected=group_cols_selected
       )
   } else {
-    stop("Please report this as a bug: Invalid data_name") # nocov
+    rlang::abort("Please report this as a bug: Invalid data_name", class = "pknca_error_internal_invalid_data_name")  # nocov
   }
   ret
 }
@@ -302,10 +302,11 @@ check_reserved_column_names <- function(x) {
 #' @noRd
 #' @keywords Internal
 standardize_column_names <- function(x, cols, group_cols=NULL, insert_if_missing=list()) {
-  checkmate::assert_list(cols, .var.name = "cols")
-  checkmate::assert_named(cols, .var.name = "cols")
+  checkmate::assert_list(cols)
+  checkmate::assert_named(cols)
+  # `.var.name` is kept here because the default would report `unlist(cols)`
   checkmate::assert_subset(unlist(cols), choices = names(x), .var.name = "cols")
-  checkmate::assert_character(group_cols, null.ok = TRUE,.var.name = "group_cols")
+  checkmate::assert_character(group_cols, null.ok = TRUE)
   if (!is.null(group_cols) && (length(group_cols) > 0)) {
     # Give a clear error message if group columns overlap
     mask_overlap_colvalues <- group_cols %in% unlist(cols)

--- a/R/set_and_assert_intervals.R
+++ b/R/set_and_assert_intervals.R
@@ -34,7 +34,7 @@ set_intervals <- function(data, intervals) {
 #' @export
 assert_intervals <- function(intervals, data) {
   checkmate::assert_data_frame(intervals)
-  checkmate::assert_class(data, classes = "PKNCAdata", .var.name = "data")
+  checkmate::assert_class(data, classes = "PKNCAdata")
 
   allowed_columns <-
     c(

--- a/R/time.above.R
+++ b/R/time.above.R
@@ -77,7 +77,7 @@ pk.calc.time_above <- function(conc, time,
       )
   } else {
     # Should be caught by the method assignment above
-    stop("Invalid 'method', please report this as a bug: ", method) # nocov
+    rlang::abort(sprintf("Invalid 'method', please report this as a bug: %s", method), class = "pknca_error_internal_invalid_time_above_method")  # nocov
   }
   ret
 }

--- a/R/unit-support.R
+++ b/R/unit-support.R
@@ -126,15 +126,7 @@ pknca_units_table.default <- function(concu, doseu, amountu, timeu,
 
   extra_cols <- setdiff(ret$PPTESTCD, names(get.interval.cols()))
   if (length(extra_cols) > 0) {
-    # nocov start
-    rlang::abort(
-      sprintf(
-        "Please report a bug. Unknown NCA parameters have units defined: %s",
-        paste(extra_cols, collapse = ", ")
-      ),
-      class = "pknca_error_internal_unknown_nca_units"
-    )
-    # nocov end
+    rlang::abort(sprintf("Please report a bug. Unknown NCA parameters have units defined: %s", paste(extra_cols, collapse = ", ")), class = "pknca_error_internal_unknown_nca_units")  # nocov
   }
 
   # Apply conversion factors


### PR DESCRIPTION
Three items were prepared while #548 was open but did not land before it merged.

Five rlang::abort() calls carrying `# nocov` are collapsed onto one line, so the marker is a trailing comment rather than a `# nocov start` / `# nocov end` bracket.  interpolate.conc.R drops from three bracketed regions to none.

The last two base stop() calls left by #548's sweep -- in prepare_data.R and time.above.R -- become classed rlang::abort() calls, and time.above.R's multi-argument message becomes a sprintf template so the text can be grepped for.

Redundant `.var.name` arguments are dropped where they repeat what checkmate already reports.  The fifteen that remain are kept deliberately: the thirteen in PKNCA.options.R would degrade to "Assertion on 'x'", prepare_data.R's would report `unlist(cols)`, and superposition.R's disambiguates a checkmate::assert() with two candidate checks.

Not covered here: R/bioequivalence.R and the conditions added by #588 to R/superposition.R both use base stop()/warning().  They arrived after #548's merge base and are a separate migration.