### PR TITLE
Return NA rather than 0 when a summed input is zero-length

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,13 @@ the dosing including dose amount and route.
 
 # Development version
 
+* Bug fix: `pk.calc.cl()`, `pk.calc.totdose()`, `pk.calc.ae()`,
+  `pk.calc.clr()`, and `pk.calc.fe()` return `NA` rather than 0 when an input
+  is zero-length.  `sum()` of nothing is 0, so a clearance calculated without
+  a dose was reported as 0 instead of as missing (601).  Counting parameters
+  such as `pk.calc.count_conc()` still return 0, which is their documented
+  behavior.
+
 * PKNCA now declares a minimum R version of 4.4 in DESCRIPTION, and
   continuous integration tests it.  The floor comes from `Matrix`, which
   requires R >= 4.4 and is needed by `lme4` and so by the bioequivalence

--- a/R/pk.calc.simple.R
+++ b/R/pk.calc.simple.R
@@ -615,6 +615,10 @@ add.interval.col("kel.sparse.last",
 #' @family Clearance and volume parameters
 #' @export
 pk.calc.cl <- function(dose, auc) {
+  # sum() of nothing is 0, which would be a wrong answer, not a missing one
+  if (length(dose) == 0) {
+    return(NA_real_)
+  }
   if (length(auc) == 1) {
     dose <- sum(dose)
   }
@@ -1750,6 +1754,9 @@ add.interval.col(
 #' @returns The total dose for an interval
 #' @export
 pk.calc.totdose <- function(dose) {
+  if (length(dose) == 0) {
+    return(NA_real_)
+  }
   sum(dose)
 }
 add.interval.col(

--- a/R/pk.calc.urine.R
+++ b/R/pk.calc.urine.R
@@ -36,7 +36,12 @@ pk.calc.ae <- function(conc, volume, check=TRUE) {
                                            name_a = "concentrations",
                                            name_b = "volumes")
 
-  ret <- sum(conc * volume)
+  ret <-
+    if (length(conc) == 0 || length(volume) == 0) {
+      NA_real_
+    } else {
+      sum(conc * volume)
+    }
   if (length(message_all) != 0) {
     message <- paste(message_all, collapse = "; ")
     ret <- structure(ret, exclude = message)
@@ -65,6 +70,9 @@ add.interval.col("ae",
 #' @family Urine/Excretion parameters
 #' @export
 pk.calc.clr <- function(ae, auc) {
+  if (length(ae) == 0) {
+    return(NA_real_)
+  }
   sum(ae)/auc
 }
 add.interval.col("clr.last",
@@ -114,6 +122,9 @@ add.interval.col("clr.pred",
 #' @family Urine/Excretion parameters
 #' @export
 pk.calc.fe <- function(ae, dose) {
+  if (length(ae) == 0) {
+    return(NA_real_)
+  }
   sum(ae)/dose
 }
 add.interval.col("fe",

--- a/tests/testthat/test-pk.calc.simple.R
+++ b/tests/testthat/test-pk.calc.simple.R
@@ -544,3 +544,19 @@ test_that("pk.calc.aucabove rejects non-finite conc_above", {
     regexp = "finite"
   )
 })
+
+test_that("zero-length input gives NA rather than zero (issue 601)", {
+  expect_equal(pk.calc.cl(dose = numeric(0), auc = 10), NA_real_)
+  expect_equal(pk.calc.cl(dose = NULL, auc = 10), NA_real_)
+  expect_equal(pk.calc.totdose(dose = numeric(0)), NA_real_)
+  expect_equal(pk.calc.totdose(dose = NULL), NA_real_)
+  # Unchanged for real input, including multiple doses in one interval
+  expect_equal(pk.calc.cl(dose = 100, auc = 10), 10)
+  expect_equal(pk.calc.cl(dose = c(50, 50), auc = 10), 10)
+  expect_equal(pk.calc.totdose(dose = c(50, 50)), 100)
+  # Counting parameters legitimately return zero for no measurements
+  expect_warning(
+    expect_equal(pk.calc.count_conc(conc = numeric(0)), 0),
+    class = "pknca_warning_no_concentration"
+  )
+})

--- a/tests/testthat/test-pk.calc.urine.R
+++ b/tests/testthat/test-pk.calc.urine.R
@@ -137,3 +137,17 @@ test_that("generate_missing_messages", {
     "All conc and volume are missing"
   )
 })
+
+test_that("zero-length input gives NA rather than zero (issue 601)", {
+  # pk.calc.ae() also attaches the reason for the exclusion
+  ae_empty <- pk.calc.ae(conc = numeric(0), volume = numeric(0))
+  expect_equal(as.numeric(ae_empty), NA_real_)
+  expect_match(attr(ae_empty, "exclude"), "missing")
+  expect_equal(as.numeric(pk.calc.ae(conc = NULL, volume = NULL)), NA_real_)
+  expect_equal(pk.calc.clr(ae = numeric(0), auc = 10), NA_real_)
+  expect_equal(pk.calc.fe(ae = numeric(0), dose = 100), NA_real_)
+  # Unchanged for real input
+  expect_equal(pk.calc.ae(conc = c(1, 2), volume = c(10, 10)), 30)
+  expect_equal(pk.calc.clr(ae = c(5, 5), auc = 10), 1)
+  expect_equal(pk.calc.fe(ae = c(5, 5), dose = 100), 0.1)
+})


### PR DESCRIPTION
Fixes #601.

sum() of a zero-length vector is 0, so five calculation functions returned a plausible number where the answer was unknown.  A clearance of 0 is not a missing value; it summarizes, plots, and exports like any other result.

  pk.calc.cl(dose = numeric(0), auc = 10)              was 0, now NA
  pk.calc.totdose(dose = numeric(0))                   was 0, now NA
  pk.calc.ae(conc = numeric(0), volume = numeric(0))   was 0, now NA
  pk.calc.clr(ae = numeric(0), auc = 10)               was 0, now NA
  pk.calc.fe(ae = numeric(0), dose = 100)              was 0, now NA

NA inputs already behaved correctly, which is what made the zero-length case easy to miss.

pk.calc.count_conc() and pk.calc.count_conc_measured() are unchanged: 0 is the documented answer for no measurements, and a test now pins that so the distinction is not lost.  pk.calc.c0.method.set0() is likewise unchanged, as it returns 0 by definition.