### PR TITLE
Error when a volume-dependent parameter is requested without a volume

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@ the dosing including dose amount and route.
 
 # Development version
 
+* Requesting a parameter that needs a sample volume (`ae`, `fe`, `volpk`,
+  `clr.last`, and similar) when no `volume` was given to `PKNCAconc()` is now
+  an error naming those parameters, rather than silently reporting them as
+  not calculated (#194).
+
 * Bug fix: `pk.calc.cl()`, `pk.calc.totdose()`, `pk.calc.ae()`,
   `pk.calc.clr()`, and `pk.calc.fe()` return `NA` rather than 0 when an input
   is zero-length.  `sum()` of nothing is 0, so a clearance calculated without

--- a/R/001-add.interval.col.R
+++ b/R/001-add.interval.col.R
@@ -247,8 +247,8 @@ add.interval.col <- function(name,
 
   current <- get("interval.cols", envir=.PKNCAEnv)
   # A parameter may be registered before the parameters it depends on, so the
-  # requires_dose_* values are left empty here and filled in on first use by
-  # set_requires_dose().  Re-registering an existing parameter can change what
+  # requires_* values are left empty here and filled in on first use by
+  # set_requires_inputs().  Re-registering an existing parameter can change what
   # anything downstream of it needs, so clear every cached value in that case.
   redefining <- name %in% names(current)
   current[[name]] <-
@@ -266,13 +266,15 @@ add.interval.col <- function(name,
       pptest_cdisc=pptest_cdisc,
       requires_dose_amt=NULL,
       requires_dose_time=NULL,
-      requires_dose_dur=NULL
+      requires_dose_dur=NULL,
+      requires_volume=NULL
     )
   if (redefining) {
     for (current_name in names(current)) {
       current[[current_name]][["requires_dose_amt"]] <- NULL
       current[[current_name]][["requires_dose_time"]] <- NULL
       current[[current_name]][["requires_dose_dur"]] <- NULL
+      current[[current_name]][["requires_volume"]] <- NULL
     }
   }
   assign("interval.cols", current, envir=.PKNCAEnv)

--- a/R/001-add.interval.col.R
+++ b/R/001-add.interval.col.R
@@ -246,10 +246,10 @@ add.interval.col <- function(name,
   validate_cdisc_arg(pptest_cdisc, "pptest_cdisc")
 
   current <- get("interval.cols", envir=.PKNCAEnv)
-  # A parameter may be registered before the parameters it depends on, so the
-  # requires_* values are left empty here and filled in on first use by
-  # set_requires_inputs().  Re-registering an existing parameter can change what
-  # anything downstream of it needs, so clear every cached value in that case.
+  # A parameter may be registered before the parameters it depends on, so what
+  # it requires is worked out on first use by set_requires_inputs() and cached
+  # in `requires_*` values here.  Re-registering an existing parameter can
+  # change what anything downstream of it needs, so drop every cached value.
   redefining <- name %in% names(current)
   current[[name]] <-
     list(
@@ -263,18 +263,13 @@ add.interval.col <- function(name,
       depends=depends,
       datatype=datatype,
       pptestcd_cdisc=pptestcd_cdisc,
-      pptest_cdisc=pptest_cdisc,
-      requires_dose_amt=NULL,
-      requires_dose_time=NULL,
-      requires_dose_dur=NULL,
-      requires_volume=NULL
+      pptest_cdisc=pptest_cdisc
     )
   if (redefining) {
     for (current_name in names(current)) {
-      current[[current_name]][["requires_dose_amt"]] <- NULL
-      current[[current_name]][["requires_dose_time"]] <- NULL
-      current[[current_name]][["requires_dose_dur"]] <- NULL
-      current[[current_name]][["requires_volume"]] <- NULL
+      current[[current_name]][
+        startsWith(names(current[[current_name]]), "requires_")
+      ] <- NULL
     }
   }
   assign("interval.cols", current, envir=.PKNCAEnv)

--- a/R/check.intervals.R
+++ b/R/check.intervals.R
@@ -193,16 +193,29 @@ get.parameter.deps_helper_searchdeps <- function(current, funmap, all_intervals)
   }
 }
 
+# The inputs a calculation can require, each mapped to the source-input names
+# that show the requirement.  Every entry becomes a cached `requires_<name>`
+# value on the registry entry, so a new input type is added here and nowhere
+# else.
+pknca_requires_inputs <-
+  list(
+    dose_amt = c("dose", "dose.group"),
+    dose_time = c("time.dose", "time.dose.group"),
+    dose_dur = c("duration.dose", "duration.dose.group"),
+    volume = c("volume", "volume.group")
+  )
+
 # Fill in the requires_* values for `params` and cache them in the registry,
 # computing only the ones that are not already known.  Deferred to first use
 # because a parameter may be registered before what it depends on.
 set_requires_inputs <- function(params) {
   all_intervals <- get.interval.cols()
   params <- intersect(params, names(all_intervals))
+  requires_names <- paste0("requires_", names(pknca_requires_inputs))
   unknown <-
     params[vapply(
       X = params,
-      FUN = function(x) is.null(all_intervals[[x]][["requires_dose_amt"]]),
+      FUN = function(x) !all(requires_names %in% names(all_intervals[[x]])),
       FUN.VALUE = TRUE
     )]
   if (length(unknown) > 0) {
@@ -211,14 +224,10 @@ set_requires_inputs <- function(params) {
         parameter_source_inputs(
           current_param, all_intervals = all_intervals, optional_dose = FALSE
         )
-      all_intervals[[current_param]][["requires_dose_amt"]] <-
-        any(c("dose", "dose.group") %in% current_src)
-      all_intervals[[current_param]][["requires_dose_time"]] <-
-        any(c("time.dose", "time.dose.group") %in% current_src)
-      all_intervals[[current_param]][["requires_dose_dur"]] <-
-        any(c("duration.dose", "duration.dose.group") %in% current_src)
-      all_intervals[[current_param]][["requires_volume"]] <-
-        any(c("volume", "volume.group") %in% current_src)
+      for (current_input in names(pknca_requires_inputs)) {
+        all_intervals[[current_param]][[paste0("requires_", current_input)]] <-
+          any(pknca_requires_inputs[[current_input]] %in% current_src)
+      }
     }
     assign("interval.cols", all_intervals, envir = .PKNCAEnv)
   }
@@ -237,59 +246,50 @@ requested_parameters <- function(intervals) {
   candidates[keep]
 }
 
-# Which requested parameters cannot be calculated from the dosing information
-# that was given.  Dose amount, time, and duration are supplied independently
-# (e.g. `PKNCAdose(data, ~time)` gives timing without an amount), so each is
-# checked separately: c0 needs the dose time but not the amount, and ceoi needs
-# the duration.
-uncalculable_without_dose <- function(intervals, o_dose) {
+# Which requested parameters need any of `absent`, the inputs that were not
+# given.  Names are those of `pknca_requires_inputs`.
+uncalculable_without <- function(intervals, absent) {
+  checkmate::assert_subset(absent, names(pknca_requires_inputs))
   params <- requested_parameters(intervals)
-  if (length(params) == 0) {
-    return(character(0))
-  }
-  has_dose <- !identical(o_dose, NA)
-  have_amt <- has_dose && length(o_dose$columns$dose) > 0
-  have_time <- has_dose && length(o_dose$columns$time) > 0
-  have_dur <- has_dose && length(o_dose$columns$duration) > 0
-  if (have_amt && have_time && have_dur) {
+  if (length(params) == 0 || length(absent) == 0) {
     return(character(0))
   }
   specs <- set_requires_inputs(params)
   keep <-
     vapply(
       X = specs,
-      FUN = function(x) {
-        (isTRUE(x[["requires_dose_amt"]]) && !have_amt) ||
-          (isTRUE(x[["requires_dose_time"]]) && !have_time) ||
-          (isTRUE(x[["requires_dose_dur"]]) && !have_dur)
-      },
+      FUN = function(x) any(unlist(x[paste0("requires_", absent)])),
       FUN.VALUE = TRUE
     )
   sort(names(specs)[keep])
 }
 
-# Which requested parameters need a sample volume that the data does not have.
-# A PKNCAconc object always carries a volume column, filled with NA when none
-# was given, so absence is detected by value rather than by name.  Volumes
-# missing for only some measurements are reported per-interval by the
-# calculations themselves.
-uncalculable_without_volume <- function(intervals, o_conc) {
-  params <- requested_parameters(intervals)
-  if (length(params) == 0) {
-    return(character(0))
-  }
-  volume <- getAttributeColumn(o_conc, attr_name = "volume", warn_missing = character())
-  if (!is.null(volume) && !all(is.na(volume[[1]]))) {
-    return(character(0))
-  }
-  specs <- set_requires_inputs(params)
-  keep <-
-    vapply(
-      X = specs,
-      FUN = function(x) isTRUE(x[["requires_volume"]]),
-      FUN.VALUE = TRUE
+# Dose inputs that were not given.  Amount, time, and duration are supplied
+# independently (e.g. `PKNCAdose(data, ~time)` gives timing without an amount),
+# so each is reported separately: c0 needs the dose time but not the amount,
+# and ceoi needs the duration.
+absent_dose_inputs <- function(o_dose) {
+  has_dose <- !identical(o_dose, NA)
+  present <-
+    c(
+      dose_amt = has_dose && length(o_dose$columns$dose) > 0,
+      dose_time = has_dose && length(o_dose$columns$time) > 0,
+      dose_dur = has_dose && length(o_dose$columns$duration) > 0
     )
-  sort(names(specs)[keep])
+  names(present)[!present]
+}
+
+# Concentration inputs that were not given.  A PKNCAconc object always carries
+# a volume column, filled with NA when none was given, so absence is detected
+# by value rather than by name.  Volumes missing for only some measurements are
+# reported per-interval by the calculations themselves.
+absent_conc_inputs <- function(o_conc) {
+  volume <- getAttributeColumn(o_conc, attr_name = "volume", warn_missing = character())
+  if (is.null(volume) || all(is.na(volume[[1]]))) {
+    "volume"
+  } else {
+    character(0)
+  }
 }
 
 # The inputs pk.nca.interval() supplies directly rather than calculating, so a

--- a/R/check.intervals.R
+++ b/R/check.intervals.R
@@ -193,10 +193,10 @@ get.parameter.deps_helper_searchdeps <- function(current, funmap, all_intervals)
   }
 }
 
-# Fill in the requires_dose_* values for `params` and cache them in the
-# registry, computing only the ones that are not already known.  Deferred to
-# first use because a parameter may be registered before what it depends on.
-set_requires_dose <- function(params) {
+# Fill in the requires_* values for `params` and cache them in the registry,
+# computing only the ones that are not already known.  Deferred to first use
+# because a parameter may be registered before what it depends on.
+set_requires_inputs <- function(params) {
   all_intervals <- get.interval.cols()
   params <- intersect(params, names(all_intervals))
   unknown <-
@@ -217,6 +217,8 @@ set_requires_dose <- function(params) {
         any(c("time.dose", "time.dose.group") %in% current_src)
       all_intervals[[current_param]][["requires_dose_dur"]] <-
         any(c("duration.dose", "duration.dose.group") %in% current_src)
+      all_intervals[[current_param]][["requires_volume"]] <-
+        any(c("volume", "volume.group") %in% current_src)
     }
     assign("interval.cols", all_intervals, envir = .PKNCAEnv)
   }
@@ -252,7 +254,7 @@ uncalculable_without_dose <- function(intervals, o_dose) {
   if (have_amt && have_time && have_dur) {
     return(character(0))
   }
-  specs <- set_requires_dose(params)
+  specs <- set_requires_inputs(params)
   keep <-
     vapply(
       X = specs,
@@ -261,6 +263,30 @@ uncalculable_without_dose <- function(intervals, o_dose) {
           (isTRUE(x[["requires_dose_time"]]) && !have_time) ||
           (isTRUE(x[["requires_dose_dur"]]) && !have_dur)
       },
+      FUN.VALUE = TRUE
+    )
+  sort(names(specs)[keep])
+}
+
+# Which requested parameters need a sample volume that the data does not have.
+# A PKNCAconc object always carries a volume column, filled with NA when none
+# was given, so absence is detected by value rather than by name.  Volumes
+# missing for only some measurements are reported per-interval by the
+# calculations themselves.
+uncalculable_without_volume <- function(intervals, o_conc) {
+  params <- requested_parameters(intervals)
+  if (length(params) == 0) {
+    return(character(0))
+  }
+  volume <- getAttributeColumn(o_conc, attr_name = "volume", warn_missing = character())
+  if (!is.null(volume) && !all(is.na(volume[[1]]))) {
+    return(character(0))
+  }
+  specs <- set_requires_inputs(params)
+  keep <-
+    vapply(
+      X = specs,
+      FUN = function(x) isTRUE(x[["requires_volume"]]),
       FUN.VALUE = TRUE
     )
   sort(names(specs)[keep])

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -45,7 +45,7 @@ full_join_PKNCAconc_PKNCAdose <- function(o_conc, o_dose, extra_cols_conc = char
 #' @keywords Internal
 #' @noRd
 full_join_PKNCAdata <- function(x, extra_conc_cols = character()) {
-  missing_volume_params <- uncalculable_without_volume(x$intervals, x$conc)
+  missing_volume_params <- uncalculable_without(x$intervals, absent_conc_inputs(x$conc))
   if (length(missing_volume_params) > 0) {
     rlang::abort(
       sprintf(
@@ -55,7 +55,7 @@ full_join_PKNCAdata <- function(x, extra_conc_cols = character()) {
       class = "pknca_error_missing_volume"
     )
   }
-  missing_dose_params <- uncalculable_without_dose(x$intervals, x$dose)
+  missing_dose_params <- uncalculable_without(x$intervals, absent_dose_inputs(x$dose))
   if (length(missing_dose_params) > 0) {
     rlang::inform(
       sprintf(

--- a/R/prepare_data.R
+++ b/R/prepare_data.R
@@ -45,6 +45,16 @@ full_join_PKNCAconc_PKNCAdose <- function(o_conc, o_dose, extra_cols_conc = char
 #' @keywords Internal
 #' @noRd
 full_join_PKNCAdata <- function(x, extra_conc_cols = character()) {
+  missing_volume_params <- uncalculable_without_volume(x$intervals, x$conc)
+  if (length(missing_volume_params) > 0) {
+    rlang::abort(
+      sprintf(
+        "No sample volume was given (see the `volume` argument to `PKNCAconc()`); these parameters cannot be calculated: %s",
+        paste(missing_volume_params, collapse = ", ")
+      ),
+      class = "pknca_error_missing_volume"
+    )
+  }
   missing_dose_params <- uncalculable_without_dose(x$intervals, x$dose)
   if (length(missing_dose_params) > 0) {
     rlang::inform(

--- a/tests/testthat/test-check.intervals.R
+++ b/tests/testthat/test-check.intervals.R
@@ -259,18 +259,18 @@ test_that("get.parameter.deps(recursive=TRUE) reaches the inputs a parameter is 
 
 test_that("dose amount, time, and duration are required separately (#538)", {
   expect_equal(
-    unlist(set_requires_dose("c0")[["c0"]][c("requires_dose_amt", "requires_dose_time", "requires_dose_dur")]),
+    unlist(set_requires_inputs("c0")[["c0"]][c("requires_dose_amt", "requires_dose_time", "requires_dose_dur")]),
     c(requires_dose_amt = FALSE, requires_dose_time = TRUE, requires_dose_dur = FALSE)
   )
   expect_equal(
-    unlist(set_requires_dose("ceoi")[["ceoi"]][c("requires_dose_amt", "requires_dose_time", "requires_dose_dur")]),
+    unlist(set_requires_inputs("ceoi")[["ceoi"]][c("requires_dose_amt", "requires_dose_time", "requires_dose_dur")]),
     c(requires_dose_amt = FALSE, requires_dose_time = FALSE, requires_dose_dur = TRUE)
   )
-  expect_true(set_requires_dose("cl.obs")[["cl.obs"]]$requires_dose_amt)
+  expect_true(set_requires_inputs("cl.obs")[["cl.obs"]]$requires_dose_amt)
   # pk.calc.half.life() uses the dose timing when present but does not need
   # it, so neither it nor anything downstream of it is reported
   for (param in c("half.life", "lambda.z", "aucinf.obs", "mrt.obs", "span.ratio")) {
-    expect_false(any(unlist(set_requires_dose(param)[[param]][
+    expect_false(any(unlist(set_requires_inputs(param)[[param]][
       c("requires_dose_amt", "requires_dose_time", "requires_dose_dur")
     ])), info = param)
   }
@@ -301,7 +301,7 @@ test_that("every derived dose requirement matches what pk.nca() can calculate (#
     length(v) == 0 || all(is.na(v))
   }
   for (param in check_params) {
-    spec <- set_requires_dose(param)[[param]]
+    spec <- set_requires_inputs(param)[[param]]
     derived <- any(unlist(spec[c("requires_dose_amt", "requires_dose_time", "requires_dose_dur")]))
     observed <- !all_na(res_with, param) && all_na(res_without, param)
     expect_equal(derived, observed, info = param)
@@ -343,5 +343,54 @@ test_that("the missing dose message names only what cannot be calculated (#538)"
     ))),
     regexp = "will not be calculated: c0",
     fixed = TRUE
+  )
+})
+
+test_that("volume is required only by the parameters that use it (#194)", {
+  expect_true(set_requires_inputs("volpk")[["volpk"]]$requires_volume)
+  expect_true(set_requires_inputs("ae")[["ae"]]$requires_volume)
+  # clr.last and fe reach volume only through ae
+  expect_true(set_requires_inputs("clr.last")[["clr.last"]]$requires_volume)
+  expect_true(set_requires_inputs("fe")[["fe"]]$requires_volume)
+  for (param in c("cmax", "tmax", "auclast", "half.life", "cl.obs", "totdose")) {
+    expect_false(set_requires_inputs(param)[[param]]$requires_volume, info = param)
+  }
+})
+
+test_that("every parameter's cached volume requirement matches a fresh walk (#194)", {
+  # Enumerating guard on the caching in set_requires_inputs(): a newly added
+  # parameter, or a flag left stale by re-registration, is caught here rather
+  # than by a wrong error when the calculation is requested.
+  for (param in names(get.interval.cols())) {
+    expect_equal(
+      set_requires_inputs(param)[[param]]$requires_volume,
+      any(c("volume", "volume.group") %in% get.parameter.deps(param, recursive = TRUE)),
+      info = param
+    )
+  }
+})
+
+test_that("uncalculable_without_volume reports the requested volume parameters (#194)", {
+  d_conc <- data.frame(conc = c(2, 1, 0.5, 0.25, 0.125), time = 0:4, subject = 1)
+  o_novol <- PKNCAconc(d_conc, conc~time|subject)
+  o_vol <- PKNCAconc(cbind(d_conc, vol = 10), conc~time|subject, volume = "vol")
+  ivl <- data.frame(start = 0, end = Inf, ae = TRUE, cmax = TRUE)
+  expect_equal(uncalculable_without_volume(ivl, o_novol), "ae")
+  expect_equal(uncalculable_without_volume(ivl, o_vol), character(0))
+  # A volume that is missing for only some measurements is left to the
+  # per-interval missing-data exclusions
+  o_partial <-
+    PKNCAconc(
+      cbind(d_conc, vol = c(10, NA, 10, NA, 10)), conc~time|subject, volume = "vol"
+    )
+  expect_equal(uncalculable_without_volume(ivl, o_partial), character(0))
+  # Registered but not requested, and nothing requested at all
+  expect_equal(
+    uncalculable_without_volume(data.frame(start = 0, end = Inf, ae = FALSE), o_novol),
+    character(0)
+  )
+  expect_equal(
+    uncalculable_without_volume(data.frame(start = 0, end = Inf), o_novol),
+    character(0)
   )
 })

--- a/tests/testthat/test-check.intervals.R
+++ b/tests/testthat/test-check.intervals.R
@@ -370,27 +370,55 @@ test_that("every parameter's cached volume requirement matches a fresh walk (#19
   }
 })
 
-test_that("uncalculable_without_volume reports the requested volume parameters (#194)", {
+test_that("absent_dose_inputs and absent_conc_inputs report what was not given (#194)", {
   d_conc <- data.frame(conc = c(2, 1, 0.5, 0.25, 0.125), time = 0:4, subject = 1)
-  o_novol <- PKNCAconc(d_conc, conc~time|subject)
-  o_vol <- PKNCAconc(cbind(d_conc, vol = 10), conc~time|subject, volume = "vol")
-  ivl <- data.frame(start = 0, end = Inf, ae = TRUE, cmax = TRUE)
-  expect_equal(uncalculable_without_volume(ivl, o_novol), "ae")
-  expect_equal(uncalculable_without_volume(ivl, o_vol), character(0))
+  d_dose <- data.frame(dose = 100, time = 0, subject = 1)
+  expect_equal(absent_dose_inputs(PKNCAdose(d_dose, dose~time|subject)), character(0))
+  expect_equal(absent_dose_inputs(suppressMessages(PKNCAdose(d_dose, ~time|subject))), "dose_amt")
+  expect_equal(absent_dose_inputs(suppressMessages(PKNCAdose(d_dose, dose~.|subject))), "dose_time")
+  expect_equal(absent_dose_inputs(NA), c("dose_amt", "dose_time", "dose_dur"))
+  expect_equal(absent_conc_inputs(PKNCAconc(d_conc, conc~time|subject)), "volume")
+  expect_equal(
+    absent_conc_inputs(PKNCAconc(cbind(d_conc, vol = 10), conc~time|subject, volume = "vol")),
+    character(0)
+  )
   # A volume that is missing for only some measurements is left to the
   # per-interval missing-data exclusions
-  o_partial <-
-    PKNCAconc(
+  expect_equal(
+    absent_conc_inputs(PKNCAconc(
       cbind(d_conc, vol = c(10, NA, 10, NA, 10)), conc~time|subject, volume = "vol"
-    )
-  expect_equal(uncalculable_without_volume(ivl, o_partial), character(0))
-  # Registered but not requested, and nothing requested at all
-  expect_equal(
-    uncalculable_without_volume(data.frame(start = 0, end = Inf, ae = FALSE), o_novol),
+    )),
     character(0)
   )
+})
+
+test_that("uncalculable_without selects on the inputs it is given (#194)", {
+  ivl <- data.frame(start = 0, end = Inf, ae = TRUE, cmax = TRUE, c0 = TRUE, cl.obs = TRUE)
+  expect_equal(uncalculable_without(ivl, "volume"), "ae")
+  expect_equal(uncalculable_without(ivl, "dose_amt"), "cl.obs")
+  expect_equal(uncalculable_without(ivl, "dose_time"), "c0")
+  expect_equal(uncalculable_without(ivl, c("volume", "dose_amt")), c("ae", "cl.obs"))
+  # Nothing absent, requested as FALSE, and nothing requested at all
+  expect_equal(uncalculable_without(ivl, character(0)), character(0))
   expect_equal(
-    uncalculable_without_volume(data.frame(start = 0, end = Inf), o_novol),
+    uncalculable_without(data.frame(start = 0, end = Inf, ae = FALSE), "volume"),
     character(0)
   )
+  expect_equal(uncalculable_without(data.frame(start = 0, end = Inf), "volume"), character(0))
+  expect_error(uncalculable_without(ivl, "nope"), regexp = "Must be a subset of")
+})
+
+test_that("re-registering a parameter drops every cached requirement (#194)", {
+  # A parameter registered later can change what an earlier one needs, so a
+  # cached value left behind would be wrong with nothing else failing.
+  original_state <- get("interval.cols", envir = .PKNCAEnv)
+  on.exit(assign("interval.cols", original_state, envir = .PKNCAEnv))
+  cached <- function(param) any(startsWith(names(get.interval.cols()[[param]]), "requires_"))
+  expect_true(set_requires_inputs("ae")[["ae"]]$requires_volume)
+  # A name that is not already registered is not a redefinition
+  add.interval.col(name = "zz", FUN = "mean", unit_type = "conc", pretty_name = "zz")
+  expect_true(cached("ae"))
+  add.interval.col(name = "zz", FUN = "mean", unit_type = "conc", pretty_name = "zz")
+  expect_false(cached("ae"))
+  expect_true(set_requires_inputs("ae")[["ae"]]$requires_volume)
 })

--- a/tests/testthat/test-prepare_data.R
+++ b/tests/testthat/test-prepare_data.R
@@ -202,3 +202,31 @@ test_that("restore_group_col_names", {
     regexp="Intermediate group_cols are out of order"
   )
 })
+
+test_that("requesting a parameter that needs volume without one is an error (#194)", {
+  d_conc <- data.frame(conc = c(2, 1, 0.5, 0.25, 0.125), time = 0:4, subject = 1)
+  d_dose <- data.frame(dose = 100, time = 0, subject = 1)
+  o_conc <- PKNCAconc(d_conc, conc~time|subject)
+  o_dose <- PKNCAdose(d_dose, dose~time|subject)
+  expect_error(
+    pk.nca(PKNCAdata(o_conc, o_dose, intervals = data.frame(start = 0, end = Inf, ae = TRUE))),
+    regexp = "No sample volume was given.*cannot be calculated: ae",
+    class = "pknca_error_missing_volume"
+  )
+  # Parameters downstream of ae are named, and those needing no volume are not
+  expect_error(
+    pk.nca(PKNCAdata(
+      o_conc, o_dose,
+      intervals = data.frame(start = 0, end = Inf, ae = TRUE, fe = TRUE, cmax = TRUE)
+    )),
+    regexp = "cannot be calculated: ae, fe$",
+    class = "pknca_error_missing_volume"
+  )
+  # With a volume the calculation proceeds
+  o_conc_vol <- PKNCAconc(cbind(d_conc, vol = 10), conc~time|subject, volume = "vol")
+  res <-
+    suppressMessages(pk.nca(PKNCAdata(
+      o_conc_vol, o_dose, intervals = data.frame(start = 0, end = Inf, ae = TRUE)
+    )))
+  expect_equal(as.data.frame(res)$PPORRES, sum(d_conc$conc * 10))
+})


### PR DESCRIPTION
Requesting `ae` (or anything downstream of it, such as `clr.last` and `fe`) without giving `volume` to `PKNCAconc()` reported the parameter as not calculated instead of saying that the input was never supplied.

`PKNCAconc()` always creates a volume column and fills it with NA when none was given, so absence is detected by value.  A volume missing for only some measurements is left to the existing per-interval missing-data exclusions.

Which parameters need a volume is derived from the dependency walk added for issue 538 rather than listed by hand, so `set_requires_dose()` becomes `set_requires_inputs()` and caches a fourth `requires_volume` flag from the same walk.

Fixes #194.