### PR TITLE
Drop missing concentrations in superposition() before calculating

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ the dosing including dose amount and route.
 
 # Development version
 
+* Bug fix: `superposition()` drops missing concentrations before calculating.
+  They previously reached the half-life fit and stopped the calculation with
+  `NA/NaN/Inf in 'x'` (#308).
+
 * `add.interval.col()` gains `formula` and `formula_note` arguments giving the
   calculation as a LaTeX expression.  They are shown in the parameter table in
   `vignette("v03-selection-of-calculation-intervals")` (#507).

--- a/R/superposition.R
+++ b/R/superposition.R
@@ -111,6 +111,11 @@ superposition.numeric <- function(conc, time, dose.input = NULL,
       )
     }
   }
+  # Missing concentrations would otherwise reach the half-life fit and the
+  # interpolation as NA.
+  clean_conc <- clean.conc.na(conc = conc, time = time, options = options, check = FALSE)
+  conc <- clean_conc$conc
+  time <- clean_conc$time
   assert_number_between(dose.input, na.ok = FALSE, null.ok = TRUE, lower = 0)
   assert_dosetau(tau)
   assert_numeric_between(x = dose.times, lower_eq = 0, min.len = 1, upper = tau)

--- a/tests/testthat/test-superpostion.R
+++ b/tests/testthat/test-superpostion.R
@@ -665,3 +665,40 @@ test_that("superposition.PKNCAconc re-emits everything its workers produce (issu
   expect_equal(unique(trimws(messaged)), "mocked message")
   expect_equal(unique(printed), "mocked output")
 })
+
+test_that("superposition drops missing concentrations before calculating (#308)", {
+  conc <-
+    c(0, 0, 10, 31, 54, 73, 79, 62, 55, 31, 21, 10, 4, 5, 5, 5, 5, 6, 5, 8, 45,
+      92, 124, 116, 106, 93, 72, 50, 29, 15, 6, 5, 3, 2, NA, NA, 0)
+  time <-
+    c(0, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4, 6, 8, 12, 24, 48, 72, 144, 192, 240,
+      312, 312.25, 312.5, 312.75, 313, 313.5, 314, 315, 316, 318, 320, 324, 330,
+      336, 348, 360, 384, 432, 504)
+  keep <- !is.na(conc)
+  expect_equal(
+    superposition(conc = conc, time = time, tau = 12),
+    superposition(conc = conc[keep], time = time[keep], tau = 12)
+  )
+  expect_equal(
+    superposition(conc = conc, time = time, tau = 12)$conc[1],
+    166.6999215,
+    tolerance = 1e-6
+  )
+  # An NA among otherwise-zero concentrations reached `all(conc == 0)` as NA
+  expect_equal(
+    superposition(conc = c(0, 0, NA, 0), time = c(0, 1, 2, 3), tau = 12),
+    data.frame(conc = rep(0, 4), time = c(0, 1, 3, 12))
+  )
+  # conc.na is still honored, substituting the value rather than dropping the row
+  expect_equal(
+    suppressWarnings(
+      superposition(
+        conc = c(0, 5, NA, 1), time = c(0, 1, 2, 3), tau = 12,
+        options = list(conc.na = 0)
+      )
+    ),
+    suppressWarnings(
+      superposition(conc = c(0, 5, 0, 1), time = c(0, 1, 2, 3), tau = 12)
+    )
+  )
+})


### PR DESCRIPTION
Fixes #308.

`superposition()` stopped with `NA/NaN/Inf in 'x'` on concentration data containing `NA`, while the same data passed straight to `pk.calc.half.life()` worked.

`check` in `pk.calc.half.life()` gates two different things: input validation, and the `clean.conc.blq()` call that removes `NA`. `superposition()` passed `check = FALSE` because it already validates its own inputs — and silently lost the cleaning too. It is the only caller that does this.

The same unfiltered `NA` caused a second crash: with an `NA` among otherwise-zero concentrations, the all-zero shortcut `if (all(conc == 0))` raises `missing value where TRUE/FALSE needed`. It would also have propagated through `interp.extrap.conc()` into the returned profile.

Cleaning `conc`/`time` once covers all three, because everything downstream reads them.

`clean.conc.na()` is used rather than `clean.conc.blq()`: superposition interpolates through BLQ values and must keep them, and the NA-only cleaner keeps the `conc.na` option working so a numeric setting substitutes instead of dropping. The cleaning is placed after the `check.blq` guard, which still needs to see a leading `NA` and reject it.

## Testing

Four assertions covering the reprex (pinned against the hand-filtered equivalent and against the exact value at t=0), the all-zero shortcut, and the `conc.na` substitution branch. Reverting the fix makes the new test fail with the issue's exact error.

3317 tests pass, 0 failures.