### PR TITLE
Test superposition interpolation/extrapolation methods, and validate them (#247)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@ the dosing including dose amount and route.
   They previously reached the half-life fit and stopped the calculation with
   `NA/NaN/Inf in 'x'` (#308).
 
+* `superposition()` checks the `method` and `auc.type` arguments for every
+  input.  An invalid value was previously ignored when the calculation
+  required neither interpolation nor extrapolation (#247).
+
 * `add.interval.col()` gains `formula` and `formula_note` arguments giving the
   calculation as a LaTeX expression.  They are shown in the parameter table in
   `vignette("v03-selection-of-calculation-intervals")` (#507).

--- a/R/superposition.R
+++ b/R/superposition.R
@@ -157,6 +157,11 @@ superposition.numeric <- function(conc, time, dose.input = NULL,
   if (!missing(tlast)) {
     checkmate::assert_number(tlast)
   }
+  # method and auc.type are used by interp.extrap.conc(), which only sees them
+  # when interpolation or extrapolation is required; resolve and check them here
+  # so that an invalid value is an error for every input.
+  method <- PKNCA.choose.option(name = "auc.method", value = method, options = options)
+  checkmate::assert_choice(auc.type, choices = c("AUCinf", "AUClast", "AUCall"))
   # additional.times
   if (length(additional.times) > 0) {
     if (any(is.na(additional.times))) {

--- a/tests/testthat/test-superpostion.R
+++ b/tests/testthat/test-superpostion.R
@@ -650,8 +650,31 @@ test_that("superposition rejects invalid method and auc.type (#247)", {
     regexp = 'should be one of .*lin up/log down'
   )
   expect_error(
+    superposition(conc = d_method_conc, time = d_method_time, tau = 4, method = "foo", n.tau = 1),
+    regexp = 'should be one of .*lin up/log down'
+  )
+  expect_error(
     superposition(conc = d_method_conc, time = d_method_time, tau = 4, auc.type = "foo"),
-    class = "pknca_error_invalid_auc_type"
+    regexp = 'Must be element of set'
+  )
+  # tau*n.tau <= tlast requires no extrapolation, and all-zero concentrations
+  # return before any interpolation, so neither reaches interp.extrap.conc()
+  expect_error(
+    superposition(conc = d_method_conc, time = d_method_time, tau = 4, auc.type = "foo", n.tau = 1),
+    regexp = 'Must be element of set'
+  )
+  expect_error(
+    superposition(conc = rep(0, 4), time = 0:3, tau = 4, auc.type = "foo"),
+    regexp = 'Must be element of set'
+  )
+  expect_error(
+    superposition(conc = rep(0, 4), time = 0:3, tau = 4, method = "foo"),
+    regexp = 'should be one of .*lin up/log down'
+  )
+  # The documented values are case-sensitive
+  expect_error(
+    superposition(conc = d_method_conc, time = d_method_time, tau = 4, auc.type = "aucinf"),
+    regexp = 'Must be element of set'
   )
 })
 

--- a/tests/testthat/test-superpostion.R
+++ b/tests/testthat/test-superpostion.R
@@ -500,6 +500,161 @@ test_that("superposition math", {
   )
 })
 
+# A profile with a dip before tmax (t=3) and a perfectly log-linear terminal
+# phase (4, 2, 1 at t=4, 5, 6 so lambda.z=log(2)), then a BLQ at t=7.  The dip
+# separates "lin up/log down" (log through any decrease) from "lin-log" (linear
+# before tmax), and the trailing BLQ separates AUCall from AUClast.
+d_method_conc <- c(0, 4, 2, 8, 4, 2, 1, 0)
+d_method_time <- 0:7
+
+test_that("superposition interpolates with the requested method (#247)", {
+  # tau=4 with n.tau=2 makes each output concentration the sum of an
+  # interpolation in each of the two dosing intervals: conc(t) = f(t) + f(t+4).
+  # Only t=1.5 differs by method: f(1.5) interpolates the pre-tmax decrease from
+  # 4 to 2, and f(5.5) interpolates the post-tmax decrease from 2 to 1.
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5, method = "linear"
+    ),
+    # f(1.5)=3, f(5.5)=1.5
+    data.frame(conc = c(4, 6, 4.5, 3, 8.5, 4.25), time = c(0, 1, 1.5, 2, 3, 4))
+  )
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5, method = "lin up/log down"
+    ),
+    # both decreases are log: f(1.5)=2*sqrt(2), f(5.5)=sqrt(2)
+    data.frame(conc = c(4, 6, 3*sqrt(2), 3, 8.5, 4.25), time = c(0, 1, 1.5, 2, 3, 4))
+  )
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5, method = "lin-log"
+    ),
+    # linear before tmax and log after: f(1.5)=3, f(5.5)=sqrt(2)
+    data.frame(conc = c(4, 6, 3+sqrt(2), 3, 8.5, 4.25), time = c(0, 1, 1.5, 2, 3, 4))
+  )
+  # The default is the auc.method option, "lin up/log down"
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5
+    ),
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5, method = "lin up/log down"
+    )
+  )
+  # The method may also be set through the options, and the argument wins over
+  # the option.
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5, options = list(auc.method = "lin-log")
+    ),
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5, method = "lin-log"
+    )
+  )
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5, method = "linear",
+      options = list(auc.method = "lin-log")
+    ),
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 4, n.tau = 2,
+      additional.times = 1.5, method = "linear"
+    )
+  )
+})
+
+test_that("superposition extrapolates with the requested auc.type (#247)", {
+  # tau=8 with n.tau=1 leaves the observed concentrations through tlast=6 alone
+  # and extrapolates at t=6.5, 7, and 8, where the three auc.type values differ.
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 8, n.tau = 1,
+      additional.times = 6.5, auc.type = "AUCinf"
+    ),
+    # clast=1 at tlast=6 decaying with lambda.z=log(2)
+    data.frame(
+      conc = c(0, 4, 2, 8, 4, 2, 1, 1/sqrt(2), 0.5, 0.25),
+      time = c(0:6, 6.5, 7, 8)
+    )
+  )
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 8, n.tau = 1,
+      additional.times = 6.5, auc.type = "AUClast"
+    ),
+    # everything after tlast is zero
+    data.frame(conc = c(0, 4, 2, 8, 4, 2, 1, 0, 0, 0), time = c(0:6, 6.5, 7, 8))
+  )
+  expect_equal(
+    superposition(
+      conc = d_method_conc, time = d_method_time, tau = 8, n.tau = 1,
+      additional.times = 6.5, auc.type = "AUCall"
+    ),
+    # the triangle from clast=1 at t=6 down to the BLQ at t=7, then zero
+    data.frame(conc = c(0, 4, 2, 8, 4, 2, 1, 0.5, 0, 0), time = c(0:6, 6.5, 7, 8))
+  )
+  # Without a BLQ measurement after tlast there is no triangle, so AUCall
+  # extrapolates as zero just like AUClast.
+  expect_equal(
+    superposition(
+      conc = d_method_conc[1:7], time = d_method_time[1:7], tau = 8, n.tau = 1,
+      additional.times = 6.5, auc.type = "AUCall"
+    ),
+    superposition(
+      conc = d_method_conc[1:7], time = d_method_time[1:7], tau = 8, n.tau = 1,
+      additional.times = 6.5, auc.type = "AUClast"
+    )
+  )
+})
+
+test_that("superposition.PKNCAconc passes method and auc.type to each group (#247)", {
+  o_conc <-
+    PKNCAconc(
+      data.frame(
+        ID = rep(1:2, each = length(d_method_conc)),
+        conc = rep(d_method_conc, 2),
+        time = rep(d_method_time, 2)
+      ),
+      conc~time|ID
+    )
+  expect_equal(
+    superposition(o_conc, tau = 4, n.tau = 2, additional.times = 1.5, method = "lin-log"),
+    tibble::tibble(
+      ID = rep(1:2, each = 6),
+      conc = rep(c(4, 6, 3+sqrt(2), 3, 8.5, 4.25), 2),
+      time = rep(c(0, 1, 1.5, 2, 3, 4), 2)
+    )
+  )
+  expect_equal(
+    superposition(o_conc, tau = 8, n.tau = 1, additional.times = 6.5, auc.type = "AUCall"),
+    tibble::tibble(
+      ID = rep(1:2, each = 10),
+      conc = rep(c(0, 4, 2, 8, 4, 2, 1, 0.5, 0, 0), 2),
+      time = rep(c(0:6, 6.5, 7, 8), 2)
+    )
+  )
+})
+
+test_that("superposition rejects invalid method and auc.type (#247)", {
+  expect_error(
+    superposition(conc = d_method_conc, time = d_method_time, tau = 4, method = "foo"),
+    regexp = 'should be one of .*lin up/log down'
+  )
+  expect_error(
+    superposition(conc = d_method_conc, time = d_method_time, tau = 4, auc.type = "foo"),
+    class = "pknca_error_invalid_auc_type"
+  )
+})
+
 test_that("PKNCAconc superposition", {
   myconc <- PKNCAconc(conc~time|ID,
                       data=data.frame(ID=rep(1:2, each=7),


### PR DESCRIPTION
`superposition()` passes `method` and `auc.type` through to `interp.extrap.conc()`, but no test exercised anything other than the default `"lin up/log down"`, and `auc.type = "AUCall"` was untested entirely.

**Tests** are built on one profile — `conc = c(0, 4, 2, 8, 4, 2, 1, 0)`, `time = 0:7` — with a dip before tmax (separates `lin-log` from `lin up/log down`), an exactly log-linear tail so λz = log 2 makes extrapolation hand-computable, and a trailing BLQ (separates `AUCall` from `AUClast`):

- each `method`, checked with `tau = 4, n.tau = 2` so the method must apply in both dosing intervals
- each `auc.type`, checked at three times after tlast; plus `AUCall` collapsing to `AUClast` when no BLQ follows tlast
- the `auc.method` option, and an explicit `method=` overriding it
- both arguments surviving the `superposition.PKNCAconc()` `...` → `mclapply()` path

**Validation:** `method` and `auc.type` were only checked where they were used, so an invalid value was silently ignored when `tau*n.tau <= tlast` or when all concentrations were zero. They are now checked with the other inputs. Note that this makes `auc.type` case-sensitive in `superposition()`, matching `choose_interval_method()` and `pk.calc.auxc()`; `extrapolate.conc()`'s `tolower()` previously accepted e.g. `"aucinf"`.

Closes #247