### PR TITLE
Fix missing dose time imputed into AUCint, and stop asking for bug reports on user errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,12 @@ the dosing including dose amount and route.
 
 # Development version
 
+* Bug fix: the dose-aware interval parameters (`aucint.last.dose`,
+  `aumcint.inf.pred.dose`, and the rest of the `*int.*.dose` family) return
+  `NA` when the dose time is missing.  With no dosing data, the dose time was
+  `NA`, which became a time point to interpolate to and stopped the calculation
+  with `Assertion on 'time' failed: Contains missing values` (#367).
+
 * Bug fix: `superposition()` drops missing concentrations before calculating.
   They previously reached the half-life fit and stopped the calculation with
   `NA/NaN/Inf in 'x'` (#308).

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,13 @@ the dosing including dose amount and route.
 
 # Development version
 
+* `pk.nca()` only asks for a bug report when it did not diagnose the error
+  itself.  A parameter that needs a value from the interval specification
+  (`conc_above` for `time_above`, `dose1` and `dose2` for `f`, `tau` for
+  `mrt.md.obs` and similar) now names the parameter and says to give it as an
+  interval column, instead of prefixing "Please report a bug." to an error that
+  is not one (#367).
+
 * Bug fix: the dose-aware interval parameters (`aucint.last.dose`,
   `aumcint.inf.pred.dose`, and the rest of the `*int.*.dose` family) return
   `NA` when the dose time is missing.  With no dosing data, the dose time was

--- a/R/aucint.R
+++ b/R/aucint.R
@@ -19,7 +19,9 @@
 #' @param time.dose,route,duration.dose The time of doses, route of
 #'   administration, and duration of dose used with interpolation and
 #'   extrapolation of concentration data (see [interp.extrap.conc.dose()]).
-#'   If `NULL`, [interp.extrap.conc()] will be used instead.
+#'   If `NULL`, [interp.extrap.conc()] will be used instead.  If any `time.dose`
+#'   is `NA`, the dose-aware result is `NA` because the dose cannot be placed on
+#'   the timeline.
 #' @param fun_linear,fun_log,fun_inf Integration functions for linear,
 #'   logarithmic, and infinite extrapolation methods.
 #' @param ... Additional arguments passed to `pk.calc.auxc` and
@@ -51,6 +53,12 @@ pk.calc.auxcint <- function(conc, time,
   # Check inputs
   auc.type <- match.arg(auc.type)
   method <- PKNCA.choose.option(name="auc.method", value=method, options=options)
+  if (!is.null(time.dose) && any(is.na(time.dose))) {
+    # Dose-aware interpolation cannot place a dose at an unknown time, and the
+    # unknown time must not become a point to interpolate to.
+    rlang::warn("time.dose is NA", class = "pknca_warning_timedose_na")
+    return(structure(NA_real_, exclude = "dose time is missing"))
+  }
   if (check) {
     assert_conc_time(conc, time)
     data <-

--- a/R/cleaners.R
+++ b/R/cleaners.R
@@ -132,7 +132,7 @@ clean.conc.blq <- function(conc, time,
       } else if (time_type == "after.tmax") {
         mask <- tmax <= ret$time & ret$conc %in% 0
       } else {
-        rlang::abort("There is a bug in cleaning the conc.blq with position names", class = "pknca_error_conc_blq_position_bug")  # nocov
+        rlang::abort("There is a bug in cleaning the conc.blq with position names", class = "pknca_error_internal_conc_blq_position")  # nocov
       }
       # Choose the rule to apply
       this_rule <- unname(conc.blq)[[i]]

--- a/R/interpolate.conc.R
+++ b/R/interpolate.conc.R
@@ -467,7 +467,7 @@ interp.extrap.conc.dose <- function(conc, time,
   }
   if (any(mask_no_method <- is.na(data_all$method))) {
     # This should never happen, all eventualities should be covered
-    rlang::abort(sprintf("No method for imputing concentration at time(s): %s", paste(unique(data_all$time[mask_no_method]), collapse = ", ")), class = "pknca_error_no_interp_method")  # nocov
+    rlang::abort(sprintf("No method for imputing concentration at time(s): %s", paste(unique(data_all$time[mask_no_method]), collapse = ", ")), class = "pknca_error_internal_no_interp_method")  # nocov
   }
   # Filter to the requested time points and output
   data_out <- data_all[data_all$out,,drop=FALSE]

--- a/R/pk.calc.all.R
+++ b/R/pk.calc.all.R
@@ -207,6 +207,24 @@ any_sparse_dense_in_interval <- function(interval, sparse) {
   )
 }
 
+# Re-raise an error from a single interval calculation with the interval named.
+#
+# PKNCA raises a `pknca_error_*` condition wherever it has diagnosed the problem
+# itself, and those messages already say what the user has to change.  A
+# `pknca_error_internal_*` condition, or anything unclassed arriving from base R
+# or another package, is a case PKNCA did not anticipate, so only those ask for a
+# bug report.
+interval_calculation_error <- function(e, error_preamble) {
+  diagnosed <-
+    any(grepl("^pknca_error_", class(e))) &&
+    !any(grepl("^pknca_error_internal_", class(e)))
+  msg <- sprintf("%s: %s", error_preamble, e$message)
+  if (!diagnosed) {
+    msg <- paste("Please report a bug.", msg, sep = "\n")
+  }
+  rlang::abort(msg, class = "pknca_error_interval_calculation", parent = e)
+}
+
 # Subset data down to just the times of interest and then pass it
 # further to the calculation routines.
 #
@@ -347,9 +365,7 @@ pk.nca.intervals <- function(data_conc, data_dose, data_intervals, sparse,
         calculated_interval <-
           tryCatch(
             do.call(pk.nca.interval, args),
-            error = function(e) {
-              rlang::abort(sprintf("Please report a bug.\n%s: %s", error_preamble, e$message), class = "pknca_error_interval_calculation", parent = e)  # nocov
-            }
+            error = function(e) interval_calculation_error(e, error_preamble = error_preamble)
           )
       }
       # Add all the new data into the output
@@ -545,17 +561,22 @@ pk.nca.interval <- function(conc, time, volume, duration.conc,
         } else {
           # Give an error if there is not a default argument.
           if (inherits(formals(get(all_intervals[[n]]$FUN))[[arg_formal]], "name")) {
-            arg_text <- # nocov start
+            arg_text <-
               if (arg_formal == arg_mapped) {
                 sprintf("'%s'", arg_formal)
               } else {
-                sprintf("'%s' mapped to '%s'", arg_formal, arg_mapped)
+                # Every formalsmap name resolves to a source input or to a
+                # parameter calculated first, so reaching here means the
+                # add.interval.col() registration is wrong, not the interval
+                sprintf("'%s' mapped to '%s'", arg_formal, arg_mapped)  # nocov
               }
+            # The interval specification is the last place an argument is looked
+            # for, so that is where the user has to supply it.
             rlang::abort(
               sprintf(
-                "Cannot find argument %s for NCA function '%s'",
-                arg_text, all_intervals[[n]]$FUN
-              ), # nocov end
+                "Cannot find argument %s for NCA parameter '%s' (calculated by '%s'); give it as a column in the interval specification",
+                arg_text, n, all_intervals[[n]]$FUN
+              ),
               class = "pknca_error_missing_nca_argument"
             )
           }

--- a/man/pk.calc.auxcint.Rd
+++ b/man/pk.calc.auxcint.Rd
@@ -152,7 +152,9 @@ extrapolation}
 \item{time.dose, route, duration.dose}{The time of doses, route of
 administration, and duration of dose used with interpolation and
 extrapolation of concentration data (see \code{\link[=interp.extrap.conc.dose]{interp.extrap.conc.dose()}}).
-If \code{NULL}, \code{\link[=interp.extrap.conc]{interp.extrap.conc()}} will be used instead.}
+If \code{NULL}, \code{\link[=interp.extrap.conc]{interp.extrap.conc()}} will be used instead.  If any \code{time.dose}
+is \code{NA}, the dose-aware result is \code{NA} because the dose cannot be placed on
+the timeline.}
 
 \item{auc.type}{The type of AUC to compute.  Choices are 'AUCinf', 'AUClast',
 and 'AUCall'.}

--- a/tests/testthat/test-aucint.R
+++ b/tests/testthat/test-aucint.R
@@ -761,3 +761,52 @@ test_that("dose-aware interval parameters are not described as dose-normalized (
   expect_equal(unname(descs[grepl("dn", descs, fixed = TRUE)]), character(0))
   expect_true(all(grepl("dose-aware", descs, fixed = TRUE)))
 })
+
+test_that("a missing dose time gives NA rather than interpolating at NA (#367)", {
+  conc <- 2^(0:-5)
+  time <- 0:5
+  expect_warning(
+    auc_na_dose <- pk.calc.aucint.last(conc = conc, time = time, start = 0, end = Inf, time.dose = NA_real_),
+    regexp = "time.dose is NA"
+  )
+  expect_equal(auc_na_dose, structure(NA_real_, exclude = "dose time is missing"))
+  expect_warning(
+    aumc_na_dose <- pk.calc.aumcint.last(conc = conc, time = time, start = 0, end = Inf, time.dose = NA_real_),
+    regexp = "time.dose is NA"
+  )
+  expect_equal(aumc_na_dose, structure(NA_real_, exclude = "dose time is missing"))
+  # One unknown dose time is enough; the others cannot make the timeline whole
+  expect_warning(
+    auc_partial_na_dose <-
+      pk.calc.aucint.last(conc = conc, time = time, start = 0, end = Inf, time.dose = c(0, NA_real_)),
+    regexp = "time.dose is NA"
+  )
+  expect_equal(auc_partial_na_dose, structure(NA_real_, exclude = "dose time is missing"))
+  # A known dose time is still used
+  expect_equal(
+    pk.calc.aucint.last(conc = conc, time = time, start = 0, end = Inf, time.dose = 0),
+    pk.calc.aucint.last(conc = conc, time = time, start = 0, end = Inf)
+  )
+})
+
+test_that("pk.nca gives NA for dose-aware interval parameters without dose data (#367)", {
+  d_conc <- data.frame(conc = 2^(0:-5), time = 0:5)
+  o_conc <- PKNCAconc(d_conc, conc~time)
+  dose_aware <- grep("int[.].*[.]dose$", names(get.interval.cols()), value = TRUE)
+  d_interval <- data.frame(start = 0, end = Inf, aucint.last = TRUE)
+  d_interval[dose_aware] <- TRUE
+  o_data <- PKNCAdata(o_conc, intervals = d_interval)
+  suppressMessages(suppressWarnings(o_nca <- pk.nca(o_data)))
+  res <- as.data.frame(o_nca)
+  res_dose_aware <- res[res$PPTESTCD %in% dose_aware, ]
+  expect_equal(sort(res_dose_aware$PPTESTCD), sort(dose_aware))
+  expect_equal(as.numeric(res_dose_aware$PPORRES), rep(NA_real_, length(dose_aware)))
+  expect_equal(res_dose_aware$exclude, rep("dose time is missing", length(dose_aware)))
+  # The dose-unaware siblings are still calculated
+  # lin up/log down (the default) with conc halving every hour: each 1-hour
+  # segment contributes (conc_k - conc_k/2)/log(2)
+  expect_equal(
+    as.numeric(res$PPORRES[res$PPTESTCD %in% "aucint.last"]),
+    sum(2^(-1:-5)) / log(2)
+  )
+})

--- a/tests/testthat/test-pk.calc.all.R
+++ b/tests/testthat/test-pk.calc.all.R
@@ -221,6 +221,78 @@ test_that("pk.nca.interval errors", {
   )
 })
 
+test_that("a parameter needing an interval column says so instead of asking for a bug report", {
+  d_conc <- data.frame(conc = 2^(0:-5), time = 0:5)
+  o_conc <- PKNCAconc(d_conc, conc~time)
+  # `conc_above` for time_above, `dose1` for f, and `tau` for mrt.md.obs all
+  # have to be given by the user as interval columns
+  needs_interval_col <-
+    list(
+      time_above = "Cannot find argument 'conc_above' for NCA parameter 'time_above' (calculated by 'pk.calc.time_above'); give it as a column in the interval specification",
+      f = "Cannot find argument 'dose1' for NCA parameter 'f' (calculated by 'pk.calc.f'); give it as a column in the interval specification",
+      mrt.md.obs = "Cannot find argument 'tau' for NCA parameter 'mrt.md.obs' (calculated by 'pk.calc.mrt.md'); give it as a column in the interval specification"
+    )
+  for (current_param in names(needs_interval_col)) {
+    d_interval <- data.frame(start = 0, end = Inf)
+    d_interval[[current_param]] <- TRUE
+    o_data <- PKNCAdata(o_conc, intervals = d_interval)
+    # purrr wraps the error it gets from pk.nca(), so the text is checked in the
+    # whole chain rather than in the top condition
+    current_message <-
+      conditionMessage(tryCatch(
+        suppressMessages(suppressWarnings(pk.nca(o_data))),
+        error = function(e) e
+      ))
+    expect_true(grepl(needs_interval_col[[current_param]], current_message, fixed = TRUE))
+    expect_false(grepl("report a bug", current_message, fixed = TRUE))
+  }
+  # Supplying the column makes the parameter calculable
+  o_data <- PKNCAdata(o_conc, intervals = data.frame(start = 0, end = Inf, time_above = TRUE, conc_above = 0.2))
+  suppressMessages(suppressWarnings(o_nca <- pk.nca(o_data)))
+  expect_equal(as.data.frame(o_nca)$PPTESTCD, "time_above")
+})
+
+test_that("interval_calculation_error asks for a bug report only when PKNCA did not diagnose the error", {
+  preamble <- "Error with interval start=0, end=Inf"
+  # Diagnosed by PKNCA: the message already says what to change
+  err_diagnosed <-
+    tryCatch(
+      interval_calculation_error(
+        rlang::catch_cnd(rlang::abort("say what to change", class = "pknca_error_invalid_route")),
+        error_preamble = preamble
+      ),
+      error = function(e) e
+    )
+  expect_s3_class(err_diagnosed, "pknca_error_interval_calculation")
+  expect_equal(err_diagnosed$message, paste0(preamble, ": say what to change"))
+  # Internal: PKNCA did not expect this
+  err_internal <-
+    tryCatch(
+      interval_calculation_error(
+        rlang::catch_cnd(rlang::abort("should not happen", class = "pknca_error_internal_tlast")),
+        error_preamble = preamble
+      ),
+      error = function(e) e
+    )
+  expect_equal(
+    err_internal$message,
+    paste0("Please report a bug.\n", preamble, ": should not happen")
+  )
+  # Unclassed errors from outside PKNCA are also unexpected
+  err_unclassed <-
+    tryCatch(
+      interval_calculation_error(
+        rlang::catch_cnd(stop("from somewhere else")),
+        error_preamble = preamble
+      ),
+      error = function(e) e
+    )
+  expect_equal(
+    err_unclassed$message,
+    paste0("Please report a bug.\n", preamble, ": from somewhere else")
+  )
+})
+
 test_that("Calculations when dose time is missing", {
   # Ensure that the correct number of doses are included in parameters that use dosing.
   tmpconc <- generate.conc(2, 1, 0:24)


### PR DESCRIPTION
Fixes #367

## Missing value imputed for time

With no dosing data, `pk.nca()` supplies a sentinel dose row with `time = NA_real_`. The dose-aware interval parameters (`aucint.last.dose`, `aumcint.inf.pred.dose`, and the rest of the `*int.*.dose` family) map `time.dose` to that column, so `pk.calc.auxcint()` both added `NA` to the set of times to interpolate to and handed `NA` to `interp.extrap.conc.dose()` as a dose to place on the timeline. The `NA` reached `assert_time()` and aborted the entire `pk.nca()` run:

```
Error with interval start=0, end=Inf: Assertion on 'time' failed: Contains missing values (element 1).
```

`pk.calc.auxcint()` now guards `time.dose` the way `pk.calc.c0()` already does — same `pknca_warning_timedose_na` class, same `exclude` idiom — so each dose-aware parameter reports `NA` with `exclude = "dose time is missing"`, matching the message `pk.nca()` already emits about missing dosing information. The dose-unaware siblings still calculate.

## "Please report a bug."

`pk.nca.intervals()` prefixed that to every error from an interval calculation, including ones PKNCA raised itself to say what the user has to change. Requesting `time_above`, `f`, or `mrt.md.obs` without the interval column each needs reported a bug rather than the missing column.

The prefix is now applied only to `pknca_error_internal_*` conditions and to unclassed errors from outside PKNCA. Two "should never happen" classes predating that convention are renamed into it so the split is mechanical. The missing-argument error also names the parameter and says to give the value as an interval column.

Both error sites were marked `# nocov` as unreachable; they are reachable, so those markers are removed and tests added.

## Not addressed

Running the issue's reprex verbatim still errors, on pre-existing intentional behavior rather than this bug:

- Missing `volume` errors naming `ae`, `fe`, `volpk`, `clr.*` — the behavior added in #194.
- `f`, `time_above`, `mrt.md.*`, `vss.md.*` need interval columns the user must supply (`dose1`/`dose2`, `conc_above`, `tau`) — the `non_pknca_covered_params` that the #473 test deliberately excludes. Their error message is now actionable.