### PR TITLE
Document how the concentration counts treat imputed values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,12 @@ the dosing including dose amount and route.
 
 # Development version
 
+* `pk.calc.count_conc()` and `pk.calc.count_conc_measured()` document how they
+  treat imputed concentrations.  Neither distinguishes an imputed concentration
+  from a measured one, and `count_conc_measured` counts by value:  an imputed
+  zero is excluded because it is not above the limit of quantification, while a
+  concentration carried to the start time or a fabricated minimum is counted.
+
 * A new imputation method, `start_predose_conc0`, uses a predose concentration
   as the start concentration when one is available and 0 when it is not, and
   keeps a concentration measured at the start time.  The chain

--- a/R/pk.calc.simple.R
+++ b/R/pk.calc.simple.R
@@ -1944,6 +1944,21 @@ add.interval.col(
 #' samples for a calculation and to ensure that data are consistent between
 #' individuals.
 #'
+#' @section Imputed concentrations:
+#'
+#' Both counts are taken after imputation, and neither distinguishes an imputed
+#' concentration from a measured one.  `count_conc` counts every non-missing
+#' concentration, so any imputation that adds a point increases it.
+#' `count_conc_measured` counts concentrations above the limit of
+#' quantification, so whether an imputed point is counted depends on its value
+#' rather than on its being imputed:  the zero added by
+#' [PKNCA_impute_method_start_conc0()] is not counted, while the concentration
+#' carried to the start time by [PKNCA_impute_method_start_predose()] and the
+#' minimum added by [PKNCA_impute_method_start_cmin()] are.
+#'
+#' To count only measured samples, calculate the counts in an interval with no
+#' imputation.
+#'
 #' @inheritParams pk.calc.cmax
 #' @returns a count of the non-missing concentrations (0 if all concentrations
 #'   are missing)
@@ -1976,7 +1991,10 @@ add.interval.col(
 #'   interval
 #'
 #' @returns a count of the non-missing, measured (not below or above the limit
-#'   of quantification) concentrations (0 if all concentrations are missing)
+#'   of quantification) concentrations (0 if all concentrations are missing).
+#'   "Measured" here means above the limit of quantification; an imputed
+#'   concentration above it is counted (see the "Imputed concentrations"
+#'   section).
 #' @export
 pk.calc.count_conc_measured <- function(conc, check=TRUE) {
   if (check) {

--- a/man/pk.calc.count_conc.Rd
+++ b/man/pk.calc.count_conc.Rd
@@ -19,7 +19,10 @@ a count of the non-missing concentrations (0 if all concentrations
 are missing)
 
 a count of the non-missing, measured (not below or above the limit
-of quantification) concentrations (0 if all concentrations are missing)
+of quantification) concentrations (0 if all concentrations are missing).
+"Measured" here means above the limit of quantification; an imputed
+concentration above it is counted (see the "Imputed concentrations"
+section).
 }
 \description{
 \code{count_conc} and \code{count_conc_measured} are typically used for quality control
@@ -34,6 +37,23 @@ that are not missing, above, or below the limit of quantification in an
 interval
 
 }}
+\section{Imputed concentrations}{
+
+
+Both counts are taken after imputation, and neither distinguishes an imputed
+concentration from a measured one.  \code{count_conc} counts every non-missing
+concentration, so any imputation that adds a point increases it.
+\code{count_conc_measured} counts concentrations above the limit of
+quantification, so whether an imputed point is counted depends on its value
+rather than on its being imputed:  the zero added by
+\code{\link[=PKNCA_impute_method_start_conc0]{PKNCA_impute_method_start_conc0()}} is not counted, while the concentration
+carried to the start time by \code{\link[=PKNCA_impute_method_start_predose]{PKNCA_impute_method_start_predose()}} and the
+minimum added by \code{\link[=PKNCA_impute_method_start_cmin]{PKNCA_impute_method_start_cmin()}} are.
+
+To count only measured samples, calculate the counts in an interval with no
+imputation.
+}
+
 \seealso{
 Other NCA parameters for concentrations during the intervals:
 \code{\link[=pk.calc.c0]{pk.calc.c0()}},

--- a/tests/testthat/test-pk.calc.simple.R
+++ b/tests/testthat/test-pk.calc.simple.R
@@ -571,3 +571,37 @@ test_that("zero-length input gives NA rather than zero (issue 601)", {
     class = "pknca_warning_no_concentration"
   )
 })
+
+test_that("count_conc and count_conc_measured count imputed concentrations by value", {
+  # Documented in the "Imputed concentrations" section:  neither count knows
+  # whether a concentration was imputed, so count_conc_measured includes an
+  # imputed concentration that is above the limit of quantification and
+  # excludes an imputed zero
+  d_conc <-
+    data.frame(
+      subject = 1,
+      time = c(-0.5, 1, 2, 4, 8, 12, 24),
+      conc = c(2, 50, 40, 30, 15, 8, 2)
+    )
+  o_conc <- PKNCAconc(d_conc, conc ~ time | subject)
+  o_dose <- PKNCAdose(data.frame(subject = 1, dose = 100, time = 0), dose ~ time | subject)
+  intervals <-
+    data.frame(start = 0, end = 24, count_conc = TRUE, count_conc_measured = TRUE)
+  counts <- function(impute) {
+    o_data <- suppressMessages(PKNCAdata(o_conc, o_dose, intervals = intervals, impute = impute))
+    res <- as.data.frame(suppressMessages(suppressWarnings(pk.nca(o_data))))
+    c(
+      conc = res$PPORRES[res$PPTESTCD == "count_conc"],
+      measured = res$PPORRES[res$PPTESTCD == "count_conc_measured"]
+    )
+  }
+  # Six samples are in the 0-24 interval; the predose sample at -0.5 is not
+  expect_equal(counts(NA_character_), c(conc = 6, measured = 6))
+  # A zero is added:  counted by count_conc, not by count_conc_measured
+  expect_equal(counts("start_conc0"), c(conc = 7, measured = 6))
+  # A measured concentration is carried to the start time:  counted by both
+  expect_equal(counts("start_predose"), c(conc = 7, measured = 7))
+  # A fabricated minimum is above the limit of quantification, so it is counted
+  # by both even though it was not measured at that time
+  expect_equal(counts("start_cmin"), c(conc = 7, measured = 7))
+})


### PR DESCRIPTION
`count_conc_measured` reads as though it counts only measurements, but it counts
by **value**, not by provenance — and neither count knows whether a
concentration was imputed. Found while sweeping parameters against imputation
methods.

| Imputation | `count_conc` | `count_conc_measured` |
|---|---|---|
| none | 6 | 6 |
| `start_conc0` | 7 | 6 — the zero is not above the LOQ |
| `start_predose` | 7 | **7** — a real measurement, moved |
| `start_cmin` | 7 | **7** — fabricated, but above the LOQ |

The `start_cmin` row is the surprising one: a value that was never measured at
that time is counted as measured, because the test is `conc > 0`.

Adds an "Imputed concentrations" section to `pk.calc.count_conc()` documenting
this, notes on `count_conc_measured`'s `@returns` that "measured" means above the
limit of quantification, and says how to count only real samples (calculate the
counts in an interval with no imputation).

A test pins all four cases, so the documented behavior can't drift silently.
No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)