### PR TITLE
Fix aucint.inf.pred failing when the interval ends at infinity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,14 @@ the dosing including dose amount and route.
   function name has a dot in it, so loading the package failed with `could not
   find function "getS3method"`.  `getS3method` is now imported.
 
+* Bug fix: `aucint.inf.pred` and `aumcint.inf.pred` (and their dose-aware
+  versions) no longer fail with `tlast (...) must occur exactly once in time`
+  when the interval ends at infinity.  The concentration at tlast is calculated
+  twice so that integration up to tlast uses `clast.obs` and integration after
+  tlast starts from `clast.pred`.  When nothing in the interval follows tlast,
+  extrapolation to infinity is analytic and the duplicate only added a
+  zero-width interval, so it is now omitted (#620).
+
 * New parameters `mrt.ivmd.obs`, `mrt.ivmd.pred`, `vss.ivmd.obs`, and
   `vss.ivmd.pred` give the multiple-dose (steady-state) MRT and Vss for an IV
   infusion.  They subtract half of the infusion duration, the correction that

--- a/R/aucint.R
+++ b/R/aucint.R
@@ -86,13 +86,21 @@ pk.calc.auxcint <- function(conc, time,
   if (auc.type %in% "AUCinf") {
     tlast <- pk.calc.tlast(conc=data$conc, time=data$time)
     clast_obs <- pk.calc.clast.obs(conc=data$conc, time=data$time)
+    all_times <- c(data$time, missing_times)
+    time_after_tlast <- all_times[all_times > tlast & all_times <= interval[2]]
     if (is.na(clast) && is.na(lambda.z)) {
       # clast.pred is NA likely because the half-life was not calculable
       return(structure(NA_real_, exclude = "clast.pred is NA because the half-life is NA"))
     } else if (is.na(clast)) {
       rlang::abort("Please report a bug. clast is NA and the half-life is not NA", class = "pknca_error_internal_clast_na")  # nocov
-    } else if (clast != clast_obs && interval[2] > tlast) {
-      # If using clast.pred, we need to doubly calculate at tlast.
+    } else if (clast != clast_obs && length(time_after_tlast) > 0) {
+      # If using clast.pred, the integration is done twice at tlast: once with
+      # clast.obs to end the observed data and once with clast.pred to start the
+      # extrapolation.  That duplicate only changes the result when a later
+      # point in the interval is integrated to from clast.pred.  Extrapolation
+      # past the end of the interval is analytic from clast and tlast, so a
+      # trailing duplicate would only add a zero-width interval that makes tlast
+      # ambiguous in choose_interval_method().
       conc_clast <- clast
       time_clast <- tlast
     }

--- a/tests/testthat/test-aucint.R
+++ b/tests/testthat/test-aucint.R
@@ -380,6 +380,97 @@ test_that("aucint works with infinite intervals", {
   )
 })
 
+test_that("aucint.inf.pred works when the interval ends at infinity (#620)", {
+  concdata <- data.frame(conc = c(8, 4, 2, 1), time = 0:3)
+  lambda_z <- log(2)
+  clast_pred <- 2
+  clast_obs <- 1
+  # Starting at 0.5 requires an interpolated concentration, which is the path
+  # where the clast.pred concentration is added a second time at tlast.  With
+  # nothing after tlast in the interval, that duplicate made tlast ambiguous.
+  conc_start <- 8 * 2^-0.5
+  # lin up/log down (the default) with a monotonically decreasing profile: the
+  # log trapezoid for each segment plus clast.pred/lambda.z after tlast
+  expected_pred <-
+    (conc_start - 4) / log(conc_start / 4) * 0.5 +
+    (4 - 2) / log(4 / 2) +
+    (2 - 1) / log(2 / 1) +
+    clast_pred / lambda_z
+  auc_pred <-
+    pk.calc.aucint.inf.pred(
+      conc = concdata$conc, time = concdata$time,
+      start = 0.5, end = Inf,
+      clast.pred = clast_pred, lambda.z = lambda_z
+    )
+  expect_equal(as.numeric(auc_pred), expected_pred)
+  expect_equal(attr(auc_pred, "method"), "AUC: lin up/log down")
+
+  # AUCinf,obs and AUCinf,pred differ only by the extrapolated tail
+  auc_obs <-
+    pk.calc.aucint.inf.obs(
+      conc = concdata$conc, time = concdata$time,
+      start = 0.5, end = Inf,
+      clast.obs = clast_obs, lambda.z = lambda_z
+    )
+  expect_equal(as.numeric(auc_obs) - as.numeric(auc_pred), (clast_obs - clast_pred) / lambda_z)
+
+  # An interval that ends far after tlast converges to the infinite interval
+  expect_equal(
+    as.numeric(
+      pk.calc.aucint.inf.pred(
+        conc = concdata$conc, time = concdata$time,
+        start = 0.5, end = 200,
+        clast.pred = clast_pred, lambda.z = lambda_z
+      )
+    ),
+    expected_pred
+  )
+
+  # The same holds for AUMC
+  aumc_pred <-
+    pk.calc.aumcint.inf.pred(
+      conc = concdata$conc, time = concdata$time,
+      start = 0.5, end = Inf,
+      clast.pred = clast_pred, lambda.z = lambda_z
+    )
+  aumc_obs <-
+    pk.calc.aumcint.inf.obs(
+      conc = concdata$conc, time = concdata$time,
+      start = 0.5, end = Inf,
+      clast.obs = clast_obs, lambda.z = lambda_z
+    )
+  tlast <- 3
+  expect_equal(
+    as.numeric(aumc_obs) - as.numeric(aumc_pred),
+    (clast_obs - clast_pred) * tlast / lambda_z + (clast_obs - clast_pred) / lambda_z^2
+  )
+})
+
+test_that("pk.nca calculates aucint.inf.pred with an infinite interval end (#620)", {
+  d_conc <- data.frame(subject = 1, time = c(1, 2, 4, 8), conc = c(50, 40, 8, 2))
+  d_dose <- data.frame(subject = 1, dose = 100, time = 0)
+  o_conc <- PKNCAconc(d_conc, conc~time|subject)
+  o_dose <- PKNCAdose(d_dose, dose~time|subject)
+  o_data <-
+    PKNCAdata(
+      o_conc, o_dose,
+      intervals =
+        data.frame(
+          start = 0, end = Inf,
+          aucint.inf.obs = TRUE, aucint.inf.pred = TRUE,
+          lambda.z = TRUE, clast.obs = TRUE, clast.pred = TRUE
+        )
+    )
+  o_nca <- pk.nca(o_data)
+  res <- as.data.frame(o_nca)
+  value <- function(x) res$PPORRES[res$PPTESTCD %in% x]
+  expect_equal(value("aucint.inf.obs"), 131.08069, tolerance = 1e-6)
+  expect_equal(
+    value("aucint.inf.obs") - value("aucint.inf.pred"),
+    (value("clast.obs") - value("clast.pred")) / value("lambda.z")
+  )
+})
+
 # ============================================================================
 # Check Argument Tests
 # ============================================================================


### PR DESCRIPTION
Fixes #620.

`pk.calc.auxcint()` adds the concentration at `tlast` a second time when `clast.pred` differs from `clast.obs`, so that integration up to `tlast` uses the observed data and integration after `tlast` starts from the predicted concentration.

When the interval ends at infinity and no data point follows `tlast`, that duplicate is the last point in the interval. Extrapolation to infinity is analytic from `clast` and `tlast`, so the duplicate contributed only a zero-width interval — while making `tlast` occur twice in the time vector, so `choose_interval_method()` aborted with `tlast (8) must occur exactly once in time`.

The duplicate is now added only when a later point in the interval is actually integrated to from `clast.pred`.

## Verification

For the data in the issue, `aucint.inf.pred` is now 130.5668 against `aucint.inf.obs` of 131.0807. The difference is exactly `(clast.obs - clast.pred) / lambda.z`, and finite interval ends converge to it (`end = 24` gives 130.565; `end = 48`, `100`, and `500` all give 130.5668).

Tests cover the direct call for AUC and AUMC with a hand-derived expected value, the finite-end convergence, and the `pk.nca()` path from the issue.