### PR TITLE
fix: warn instead of erroring on over-length parameter descriptions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -237,8 +237,10 @@ the dosing including dose amount and route.
   states that a timepoint mean is zeroed when >50% of the measurements are
   BLQ (#579).
 
-* Parameter descriptions in `add.interval.col()` are now limited to 40
-  characters to comply with SDTM requirements.
+* Parameter descriptions in `add.interval.col()` longer than 40 characters now
+  warn, since SDTM requires descriptions of 40 characters or fewer.  The
+  description is still registered, so a package that supplies a longer one
+  keeps working and can shorten it before an SDTM submission.
 
 * Bug fix: `pk.nca()` no longer errors on unsorted concentration-time data.
   Group-level concentration data are now sorted by time before calculation, so

--- a/R/001-add.interval.col.R
+++ b/R/001-add.interval.col.R
@@ -203,8 +203,8 @@ assert_selection <- function(selection, name) {
 #'   name is used.)
 #' @param depends Character vector of columns that must be run before this
 #'   column.
-#' @param desc A human-readable description of the parameter (<=40 characters to
-#'   comply with SDTM)
+#' @param desc A human-readable description of the parameter.  SDTM requires
+#'   <=40 characters; a longer description is accepted with a warning.
 #' @param sparse Is the calculation for sparse PK?
 #' @param formalsmap A named list mapping parameter names in the function call
 #'   to NCA parameter names.  See the details for information on use of
@@ -343,7 +343,16 @@ add.interval.col <- function(name,
   checkmate::assert_character(x = FUN, len = 1, any.missing = TRUE) # allows NA
   checkmate::assert_logical(x = sparse, len = 1, any.missing=FALSE)
   checkmate::assert_character(x = pretty_name, len = 1, min.chars = 1, any.missing=FALSE)
-  checkmate::assert_character(x = desc, len = 1, any.missing=FALSE, max.chars = 40)
+  checkmate::assert_character(x = desc, len = 1, any.missing=FALSE)
+  if (nchar(desc) > 40) {
+    rlang::warn(
+      sprintf(
+        "`desc` is %d characters; SDTM requires <=40.  The description for %s will need to be shortened before it can be used in an SDTM submission: %s",
+        nchar(desc), sQuote(name), sQuote(desc)
+      ),
+      class = "pknca_warning_desc_too_long"
+    )
+  }
   checkmate::assert_character(x = depends, null.ok = TRUE)
   tier <- match.arg(tier, choices = pknca_tiers())
   selection <- assert_selection(selection, name = name)

--- a/man/add.interval.col.Rd
+++ b/man/add.interval.col.Rd
@@ -45,8 +45,8 @@ name is used.)}
 \item{depends}{Character vector of columns that must be run before this
 column.}
 
-\item{desc}{A human-readable description of the parameter (<=40 characters to
-comply with SDTM)}
+\item{desc}{A human-readable description of the parameter.  SDTM requires
+<=40 characters; a longer description is accepted with a warning.}
 
 \item{sparse}{Is the calculation for sparse PK?}
 

--- a/tests/testthat/test-001-add.interval.col.R
+++ b/tests/testthat/test-001-add.interval.col.R
@@ -84,14 +84,20 @@ test_that("add.interval.col", {
   # description
   ## validates desc
   # ---- Valid boundary: exactly 40 characters ----
-  expect_no_error(
+  expect_no_warning(
     add.interval.col(
       name="a", FUN=NA, unit_type="conc", pretty_name="a", datatype="interval", desc = paste(rep("a", 40), collapse = "") )
   )
   
-  # ---- Invalid boundary: 41 characters ----
-  expect_error(
-    add.interval.col(name="a", FUN=NA, unit_type="conc", pretty_name="a", datatype="interval", desc = paste(rep("a", 41), collapse = "") )
+  # ---- Over-length: 41 characters warns, but still registers ----
+  expect_warning(
+    add.interval.col(name="a", FUN=NA, unit_type="conc", pretty_name="a", datatype="interval", desc = paste(rep("a", 41), collapse = "") ),
+    regexp = "`desc` is 41 characters; SDTM requires <=40",
+    class = "pknca_warning_desc_too_long"
+  )
+  expect_equal(
+    PKNCA::get.interval.cols()[["a"]]$desc,
+    paste(rep("a", 41), collapse = "")
   )
   
   # ---- NA ----


### PR DESCRIPTION
The 40-character limit on `desc` in add.interval.col() was enforced with a checkmate assertion, so a description one character too long aborted the call. Because packages register their parameters at load time, that turned a formatting concern into an install-blocking error downstream.

A revdep check found aNCA cannot be installed against the development version at all: its "The sum of urine volumes for the interval" description is 41 characters, and the failure happens during lazy loading, before anything in aNCA can run. The GitHub version carries two further descriptions of 88 and 96 characters.

Keep the SDTM guidance and report it as a warning naming the parameter, its length, and the offending text, while still registering the description. Packages that supply a longer one keep working and can shorten it before an SDTM submission. Invalid `desc` values (NA, empty, length other than one) still error as before.

Reword the existing NEWS entry rather than adding a new one, since the limit has not appeared in a release.

Tests: 4054 passing, 0 failures.